### PR TITLE
Processing of CoNLL comments into CoNLL-RDF + CoNLL-U Plus Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ IMPORTANT USAGE HINT: All given data is parsed sentence-wise (if applicable). Me
 Synopsis: ```CoNLLStreamExtractor baseURI FIELD1[.. FIELDn] [-u SPARQL_UPDATE1..m] [-s SPARQL_SELECT]```
 
 * `baseURI` (required): ideally a resolvable URL to adhere to the five stars of LOD.
-* `FIELD1[.. FIELDn]` (required): name each column of input conll. 
+* `FIELD1[.. FIELDn]`: name each column of input conll. 
 	* at least one column name is required.
 	* note that `CoNLLStreamExtractor` will not check the number of columns. Make sure the list of fields match the number of columns of your CoNLL input. 
+	* In case input is [CoNLL-U Plus](https://universaldependencies.org/ext-format.html), we read the fieldnames from the `# global.comments = [FIELDS]` comment.
+	This comment MUST be in the first line.
 * `[-u SPARQL_UPDATE1 .. m]`: execute sparql updates before writing to stdout. 
 	* can be followed by an optional integer x in {}-parentheses = number of repetitions e.g. `-u examples/sparql/remove-ID.sparql{5}`. Will repeat the update x times or until model stops changing.
 		* `{u}` for unlimited will repeat 999 times.
@@ -100,7 +102,10 @@ Hint: The -updates parameter can take a SPARQL-update-query as a String. If this
 Synopsis: ```CoNLLRDFFormatter [-rdf [COLS]] [-debug] [-grammar] [-semantics] [-conll COLS] [-sparqltsv SPARQL]```
 
 * `-rdf` (default): writes canonical conll-rdf as .ttl.
-* `-conll [COLS]`: writes .conll of specified columns in order of arguments.  At least one COL must be provided, otherwise writes original conll-rdf.
+* `-conll [COLS]`: writes .conll of specified columns in order of arguments. 
+  * If no cols are provided, we assume the original conll was [CoNLL-U Plus](https://universaldependencies.org/ext-format.html).
+    We first search for a `rdfs:comment` property with a `global.columns` comment, then the raw conll-like comments.
+  * Note that we will overwrite any `global.columns` comments with the new column names, so you may read them with the `CoNLLStreamExtractor` again right away.
 * `-debug`: writes highlighted .ttl to `stderr`, e.g. highlighting triples representing conll columns or sentence structure differently. 
   * does not work in combination with `-conll`.
   * to add custom highlighting you can add rules to `colorTTL(String buffer)` in `CoNLLRDFFormatter.java`. Don't forget to recompile!

--- a/src/org/acoli/conll/rdf/CoNLL2RDF.java
+++ b/src/org/acoli/conll/rdf/CoNLL2RDF.java
@@ -1,12 +1,12 @@
 /*
  * Copyright [2017] [ACoLi Lab, Prof. Dr. Chiarcos, Goethe University Frankfurt]
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,24 +37,24 @@ import org.apache.log4j.Logger;
  * @author Christian Faeth {@literal faeth@em.uni-frankfurt.de}
  **/
 public class CoNLL2RDF extends Format2RDF{
-
-
+	
+	
 	public CoNLL2RDF(String baseURI, String[] fields, Writer out) throws IOException {
 		super(baseURI, fields, out);
 	}
-
+	
 	public CoNLL2RDF(String baseURI, String[] fields) throws IOException {
 		super(baseURI, fields);
 	}
 
-
+	
 	private static Logger LOG = Logger.getLogger(CoNLL2RDF.class.getName());
-
+	
 	/** @param argv baseURI field1 field2 ... (see variable <code>help</code> and method <code>conll2ttl</code>) */
-	public static void main(String[] argv) throws Exception {
+	public static void main(String[] argv) throws Exception {		
 		Format2RDF.main("CoNLL",argv);
 	}
-
+	
 	/**
 	 * See conll2ttl(Reader), but note that we write *only* to the specified writer.
 	 * If this is not the pre-defined writer out, we define the prefixes.<br>
@@ -72,7 +72,7 @@ public class CoNLL2RDF extends Format2RDF{
 		TreeSet<String> argTriples = new TreeSet<String>();
 		Set<String> argsProperties = new TreeSet<String>();
 		Set<String> headSubProperties = new TreeSet<String>();
-
+		
 		for(String line = ""; line!=null; line=bin.readLine()) {
 			//if(line.contains("#"))
 				//out.write(line.replaceFirst("^[^#]*","")); // uncomment to keep commentaries
@@ -88,7 +88,7 @@ public class CoNLL2RDF extends Format2RDF{
 					// sentence=sentence+".\n";
 					argTriples.clear();
 					if(col2field.get(col2field.size()-1).toLowerCase().matches(".*args")) {
-						for (int i = 0; i<predicates.size(); i++) {
+						for(int i = 0; i<predicates.size(); i++) {
 							sentence=sentence.replaceAll("_TMP_"+col2field.get(col2field.size()-1).replaceFirst("[\\-_]*[Aa][rR][gG][sS]$","_"+i),predicates.get(i));
 						}
 					}
@@ -103,7 +103,7 @@ public class CoNLL2RDF extends Format2RDF{
 					line=line.replaceFirst("#.*","").trim();
 					if(!line.equals("")) {
 						if(sentence.equals("")) {
-							if(sent>1) {
+							if(sent>1) { 
 								String lastRoot = ":s"+(sent-1)+"_"+0;
 								sentence=sentence+lastRoot+" nif:nextSentence "+root+".\n";
 							}
@@ -120,7 +120,7 @@ public class CoNLL2RDF extends Format2RDF{
 							throw new NumberFormatException("the ID column must contain integers, only");
 						}
 						String URI = ":s"+sent+"_"+id_string; // URI naming scheme follows the German TIGER Corpus
-
+						
 						if(tok>1)
 							sentence=sentence+"; nif:nextWord "+URI+"."+
 							//" # offset="+pos+
@@ -171,12 +171,12 @@ public class CoNLL2RDF extends Format2RDF{
 						sentence=sentence.replaceAll("\\?"+col2field.get(col2field.size()-1).replaceFirst("[\\-_]*[Aa][rR][gG][sS]$","+"+i),predicates.get(i));
 				out.write(sentence); //+"\n");
 			//out.write("\n");
-			for(String p : headSubProperties)
+			for(String p : headSubProperties) 
 				out.write(p.trim()+"\n");
 			//out.write("\n");
 			for(String p : argsProperties)
 				out.write(p.trim()+"\n");
-			out.flush();
+			out.flush();			
 		}
 			if(tok>0) {
 				sent++;

--- a/src/org/acoli/conll/rdf/CoNLL2RDF.java
+++ b/src/org/acoli/conll/rdf/CoNLL2RDF.java
@@ -239,7 +239,8 @@ public class CoNLL2RDF {
 		TreeSet<String> argTriples = new TreeSet<String>();
 		Set<String> argsProperties = new TreeSet<String>();
 		Set<String> headSubProperties = new TreeSet<String>();
-		
+		ArrayList<String> comments = new ArrayList<>();
+
 		for(String line = ""; line!=null; line=bin.readLine()) {
 			if(line.contains("#"))
 				out.write(line.replaceFirst("^[^#]*","")); // keep commentaries
@@ -259,13 +260,20 @@ public class CoNLL2RDF {
 							sentence=sentence.replaceAll("_TMP_"+col2field.get(col2field.size()-1).replaceFirst("[\\-_]*[Aa][rR][gG][sS]$","_"+i),predicates.get(i));
 						}
 					}
-					out.write(sentence+"\n");
+					if (comments.size()>0) {
+						out.write(sentence);
+						out.write(root+" rdfs:comment \""+(String.join("\\\\n",comments))+"\" ."+"\n");
+					} else
+						out.write(sentence+"\n");
 					predicates.clear();
 					sentence="";
 					tok=0;
 					sent++;
 				} else {
-					if(line.contains("#")) out.write(line.replaceFirst("^[^#]*#", "#")+"\n");
+					if(line.contains("#")) {
+						out.write(line.replaceFirst("^[^#]*#", "#")+"\n");
+						comments.add(line.replaceFirst("^[^#]*#", "#"));
+					}
 					line=line.replaceFirst("#.*","").trim();
 					if(!line.equals("")) {
 						if(sentence.equals("")) {

--- a/src/org/acoli/conll/rdf/CoNLL2RDF.java
+++ b/src/org/acoli/conll/rdf/CoNLL2RDF.java
@@ -88,10 +88,10 @@ public class CoNLL2RDF extends Format2RDF{
 					// sentence=sentence+".\n";
 					argTriples.clear();
 					if(col2field.get(col2field.size()-1).toLowerCase().matches(".*args")) {
-                        for (int i = 0; i < predicates.size(); i++) {
-                            sentence = sentence.replaceAll("_TMP_" + col2field.get(col2field.size() - 1).replaceFirst("[\\-_]*[Aa][rR][gG][sS]$", "_" + i), predicates.get(i));
-                        }
-                    }
+						for (int i = 0; i<predicates.size(); i++) {
+							sentence=sentence.replaceAll("_TMP_"+col2field.get(col2field.size()-1).replaceFirst("[\\-_]*[Aa][rR][gG][sS]$","_"+i),predicates.get(i));
+						}
+					}
 					out.write(sentence+"\n");
 					predicates.clear();
 					sentence="";

--- a/src/org/acoli/conll/rdf/CoNLL2RDF.java
+++ b/src/org/acoli/conll/rdf/CoNLL2RDF.java
@@ -385,6 +385,7 @@ public class CoNLL2RDF {
 				meanByteSizeOfLine = ((meanByteSizeOfLine * (m - 1)) + peekedLine.length()) / m;
 				LOG.debug("Mean Byte size: " + meanByteSizeOfLine);
 				peekedChars += peekedLine.length();
+				System.err.println("Peeking line: "+peekedLine);
 				if ((peekedChars + meanByteSizeOfLine) > readAheadLimit) {
 					LOG.info("Couldn't find CoNLL-U Plus columns.");
 					inputStream.reset();
@@ -394,6 +395,7 @@ public class CoNLL2RDF {
 				if (peekedLine.matches("^#\\s?global\\.columns\\s?=.*")) {
 					fields.addAll(Arrays.asList(peekedLine.trim()
 							.replaceFirst("#\\s?global\\.columns\\s?=", "")
+							.split("#")[0]
 							.trim().split(" |\t")));
 					inputStream.reset();
 					LOG.info("Success");

--- a/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
+++ b/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
@@ -569,6 +569,7 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 						comments.add(result);
 				}
 			}
+			System.err.println(select);
 			qexec = QueryExecutionFactory.create(select, m);
 			results = qexec.execSelect();
 			List<String> cols = results.getResultVars();

--- a/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
+++ b/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
@@ -584,7 +584,7 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 							comments.add(splitComment);
 					}
 				}
-				
+
 			}
 			if (hasGlobalComments)
 				out.write("# global.columns = " + String.join(" ", cols) + "\n");

--- a/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
+++ b/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
@@ -23,7 +23,7 @@ import org.apache.jena.update.*;
 import org.apache.log4j.Logger;
 import org.apache.jena.query.*;
 
-import static org.acoli.conll.rdf.CoNLLStreamExtractor.findFieldsFromComments;
+import static org.acoli.conll.rdf.CoNLL2RDF.findFieldsFromComments;
 
 
 /** reads CoNLL-RDF from stdin, writes it formatted to stdout (requires a Un*x shell)<br>
@@ -565,10 +565,9 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 			Hashtable<String,String> key2line = new Hashtable<String,String>();
 			String line;
 			while((line=in.readLine())!=null) {
-				line=line.trim();
+				line=line.trim(); // below causes trailing comment to be lost, would be disallowed by format however.
 				if (line.matches("^#\\s?global\\.columns\\s?=.*")) out.write("# global.columns = "+String.join(" ", cols)+"\n");
 				else if (line.startsWith("#")) out.write(line+"\n");
-
 			}
 
 			out.write("# "); 									// well, this may be redundant, but permitted in CoNLL
@@ -652,9 +651,7 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 				while(i<argv.length && !argv[i].toLowerCase().matches("^-+.*$"))
 					m.getCols().add(argv[i++]);
 				if (m.getCols().size() < 1) {
-					List<String> fields = new ArrayList<>(); // TODO: Can i use getter as call by reference param?
-					findFieldsFromComments(f.getInputStream(), fields, 1);
-					m.setCols(fields);
+					m.setCols(findFieldsFromComments(f.getInputStream(), 1));
 				}
 				f.getModules().add(m);
 			}
@@ -728,7 +725,6 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 								if (m.getCols().size() < 1) 
 									throw new IOException("-conll argument needs at least one COL to export!"); 
 								else {
-									System.err.println("!");
 									printSparql(buffer, columnsAsSelect(m.getCols()), new OutputStreamWriter(m.getOutputStream()));
 								}
 							}
@@ -747,7 +743,7 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 					//System.out.print("\n");
 					buffer=buffer+"\n";
 
-				if(line.trim().startsWith("#") && (!lastLine.trim().startsWith("#"))) 
+				if(line.trim().startsWith("#") && (!lastLine.trim().startsWith("#")))
 					// System.out.print("\n");
 					buffer=buffer+"\n";
 				
@@ -770,7 +766,6 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 					if (m.getCols().size() < 1) 
 						throw new IOException("-conll argument needs at least one COL to export!");
 					else {
-						System.err.println("!!");
 						printSparql(buffer, columnsAsSelect(m.getCols()), new OutputStreamWriter(m.getOutputStream()));
 					}
 				}

--- a/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
+++ b/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
@@ -569,7 +569,6 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 						comments.add(result);
 				}
 			}
-			System.err.println(select);
 			qexec = QueryExecutionFactory.create(select, m);
 			results = qexec.execSelect();
 			List<String> cols = results.getResultVars();
@@ -734,7 +733,15 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 			f.processSentenceStream();
 			
 		}
-		List<String> findColumnNamesInRDFBuffer(String buffer) {
+
+	/**
+	 * Searches a string buffer that is expected to represent a sentence for any
+	 * <code>rdfs:comment</code> properties and checks them for a CoNLL-U Plus like global.columns comments.
+	 * Defaults to an empty columnNames Array if not present.
+	 * @param buffer a string buffer representing a sentence in conll-rdf
+	 * @return ArrayList of column names, empty if not present.
+	 */
+	private List<String> findColumnNamesInRDFBuffer(String buffer) {
 			List<String> columnNames = new ArrayList<>();
 			Model m = ModelFactory.createDefaultModel().read(new StringReader(buffer),null, "TTL");
 			String selectComments = "PREFIX nif: <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#>\n"
@@ -756,6 +763,7 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 			}
 			return columnNames;
 		}
+
 		public void processSentenceStream() throws IOException {
 			String line;
 			String lastLine ="";

--- a/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
+++ b/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
@@ -19,10 +19,8 @@ import java.io.*;
 import java.net.*;
 import java.util.*;
 import org.apache.jena.rdf.model.*;		// Jena 2.x
-import org.apache.jena.update.*;
 import org.apache.log4j.Logger;
 import org.apache.jena.query.*;
-import org.acoli.conll.rdf.CoNLL2RDF;
 
 
 /** reads CoNLL-RDF from stdin, writes it formatted to stdout (requires a Un*x shell)<br>
@@ -778,7 +776,7 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 										m.setCols(conllColumns);
 									} else {
 										LOG.info("Trying conll columns now..");
-										conllColumns = CoNLL2RDF.findFieldsFromComments(new BufferedReader(new StringReader(buffer.trim())), 1);
+										conllColumns = CoNLLStreamExtractor.findFieldsFromComments(new BufferedReader(new StringReader(buffer.trim())), 1);
 										if (conllColumns.size()>0) {
 											m.setCols(conllColumns);
 										}

--- a/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
+++ b/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
@@ -824,7 +824,21 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 				if(m.getMode()==Mode.CONLLRDF) m.getOutputStream().println(reorderTTLBuffer(buffer, m.getCols()));
 				if(m.getMode()==Mode.DEBUG) System.err.println(colorTTL(reorderTTLBuffer(buffer, m.getCols())));
 				if(m.getMode()==Mode.CONLL) {
-					if (m.getCols().size() < 1) 
+					if (m.getCols().size() < 1) {
+						LOG.info("No column names in cmd args, searching rdf comments..");
+						List<String> conllColumns = findColumnNamesInRDFBuffer(buffer);
+						if (conllColumns.size()>0) {
+							LOG.info("Using #global.comments from rdf");
+							m.setCols(conllColumns);
+						} else {
+							LOG.info("Trying conll columns now..");
+							conllColumns = CoNLLStreamExtractor.findFieldsFromComments(new BufferedReader(new StringReader(buffer.trim())), 1);
+							if (conllColumns.size()>0) {
+								m.setCols(conllColumns);
+							}
+						}
+					}
+					if (m.getCols().size() < 1)
 						throw new IOException("-conll argument needs at least one COL to export!");
 					else
 						printSparql(buffer, columnsAsSelect(m.getCols()), new OutputStreamWriter(m.getOutputStream()));

--- a/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
+++ b/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
@@ -563,7 +563,7 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 			boolean hasGlobalComments = false;
 			while (results.hasNext()) {
 				for (String result : results.next().getLiteral("c").toString().split("\\\\n")) {
-					if (result.trim().matches("^#\\s?global\\.columns\\s?=.*") )
+					if (result.trim().matches("^\\s?global\\.columns\\s?=.*") )
 						hasGlobalComments = true;
 					else
 						comments.add(result);
@@ -581,7 +581,7 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 						if (splitComment.trim().matches("^#\\s?global\\.columns\\s?=.*"))
 							hasGlobalComments = true;
 						else
-							comments.add(splitComment);
+							comments.add(splitComment.replace("#",""));
 					}
 				}
 
@@ -592,7 +592,7 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 				out.write("# global.columns = "+String.join(" ", cols)+"\n");
 			}
 			for (String comment : comments) {
-				out.write(comment+"\n");
+				out.write("#"+comment+"\n");
 			}
 
 			while(results.hasNext()) {
@@ -744,9 +744,9 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 			while (results.hasNext()) {
 				String[] comments = results.next().getLiteral("c").toString().split("\\\\n");
 				for (String comment : comments) {
-					if (comment.matches("^#\\s?global\\.columns\\s?=.*")) {
+					if (comment.matches("^\\s?global\\.columns\\s?=.*")) {
 						columnNames.addAll(Arrays.asList(comment.trim()
-								.replaceFirst("#\\s?global\\.columns\\s?=", "")
+								.replaceFirst("\\s?global\\.columns\\s?=", "")
 								.trim().split(" |\t")));
 						LOG.info("Found global columns comment in rdfs:comment");
 						return columnNames;

--- a/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
+++ b/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
@@ -584,25 +584,17 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 							comments.add(splitComment);
 					}
 				}
-//                    for (String comment : commentsLinewise) {
-//                        if (comment.matches("^#\\s?global\\.columns\\s?=.*"))
-//                            out.write("# global.columns = " + String.join(" ", cols) + "\n");
-//                        else out.write(comment + "\n");
-//                    }
-//                }
+				
 			}
 			if (hasGlobalComments)
 				out.write("# global.columns = " + String.join(" ", cols) + "\n");
-
+			else {
+				out.write("# global.columns = "+String.join(" ", cols)+"\n");
+			}
 			for (String comment : comments) {
 				out.write(comment+"\n");
 			}
 
-			out.write("# "); 									// well, this may be redundant, but permitted in CoNLL
-			for(String col : cols)
-				out.write(col+"\t");
-			out.write("\n");
-			out.flush();
 			while(results.hasNext()) {
 				QuerySolution sol = results.next();
 				for(String col : cols)

--- a/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
+++ b/src/org/acoli/conll/rdf/CoNLLRDFFormatter.java
@@ -22,7 +22,7 @@ import org.apache.jena.rdf.model.*;		// Jena 2.x
 import org.apache.jena.update.*;
 import org.apache.log4j.Logger;
 import org.apache.jena.query.*;
-
+import org.acoli.conll.rdf.CoNLL2RDF;
 
 
 /** reads CoNLL-RDF from stdin, writes it formatted to stdout (requires a Un*x shell)<br>
@@ -90,7 +90,7 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 	public static enum Mode {
 		CONLLRDF, CONLL, DEBUG, SPARQLTSV, GRAMMAR, SEMANTICS, GRAMMAR_SEMANTICS
 	}
-	
+
 	private List<Module> modules = new ArrayList<Module>();
 	
 	public List<Module> getModules() {
@@ -561,9 +561,15 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 					+ "SELECT ?c WHERE {?x a nif:Sentence . ?x rdfs:comment ?c}";
 			QueryExecution qexec = QueryExecutionFactory.create(selectComments, m);
 			ResultSet results = qexec.execSelect();
-			List<String> comments = new ArrayList<>();
+			Set<String> comments = new HashSet<>();
+			boolean hasGlobalComments = false;
 			while (results.hasNext()) {
-				comments.addAll(Arrays.asList(results.next().getLiteral("c").toString().split("\\\\n")));
+				for (String result : results.next().getLiteral("c").toString().split("\\\\n")) {
+					if (result.trim().matches("^#\\s?global\\.columns\\s?=.*") )
+						hasGlobalComments = true;
+					else
+						comments.add(result);
+				}
 			}
 			qexec = QueryExecutionFactory.create(select, m);
 			results = qexec.execSelect();
@@ -572,14 +578,26 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 			Hashtable<String,String> key2line = new Hashtable<String,String>();
 			String line;
 			while((line=in.readLine())!=null) {
-                if (line.trim().startsWith("#")) {
-                    String[] commentsLinewise = line.split("\t");
-                    for (String comment : commentsLinewise) {
-                        if (comment.matches("^#\\s?global\\.columns\\s?=.*"))
-                            out.write("# global.columns = " + String.join(" ", cols) + "\n");
-                        else out.write(comment + "\n");
-                    }
-                }
+				if (line.trim().startsWith("#")) {
+					for (String splitComment : line.split("\t")) {
+						if (splitComment.trim().matches("^#\\s?global\\.columns\\s?=.*"))
+							hasGlobalComments = true;
+						else
+							comments.add(splitComment);
+					}
+				}
+//                    for (String comment : commentsLinewise) {
+//                        if (comment.matches("^#\\s?global\\.columns\\s?=.*"))
+//                            out.write("# global.columns = " + String.join(" ", cols) + "\n");
+//                        else out.write(comment + "\n");
+//                    }
+//                }
+			}
+			if (hasGlobalComments)
+				out.write("# global.columns = " + String.join(" ", cols) + "\n");
+
+			for (String comment : comments) {
+				out.write(comment+"\n");
 			}
 
 			out.write("# "); 									// well, this may be redundant, but permitted in CoNLL
@@ -662,9 +680,6 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 				while(i<argv.length && argv[i].toLowerCase().matches("^-+conll$")) i++;
 				while(i<argv.length && !argv[i].toLowerCase().matches("^-+.*$"))
 					m.getCols().add(argv[i++]);
-				if (m.getCols().size() < 1) {
-					m.setCols(CoNLL2RDF.findFieldsFromComments(f.getInputStream(), 1));
-				}
 				f.getModules().add(m);
 			}
 			
@@ -720,22 +735,58 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 			f.processSentenceStream();
 			
 		}
-
+		List<String> findColumnNamesInRDFBuffer(String buffer) {
+			List<String> columnNames = new ArrayList<>();
+			Model m = ModelFactory.createDefaultModel().read(new StringReader(buffer),null, "TTL");
+			String selectComments = "PREFIX nif: <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#>\n"
+					+ "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n"
+					+ "SELECT ?c WHERE {?x a nif:Sentence . ?x rdfs:comment ?c}";
+			QueryExecution qexec = QueryExecutionFactory.create(selectComments, m);
+			ResultSet results = qexec.execSelect();
+			while (results.hasNext()) {
+				String[] comments = results.next().getLiteral("c").toString().split("\\\\n");
+				for (String comment : comments) {
+					if (comment.matches("^#\\s?global\\.columns\\s?=.*")) {
+						columnNames.addAll(Arrays.asList(comment.trim()
+								.replaceFirst("#\\s?global\\.columns\\s?=", "")
+								.trim().split(" |\t")));
+						LOG.info("Found global columns comment in rdfs:comment");
+						return columnNames;
+					}
+				}
+			}
+			return columnNames;
+		}
 		public void processSentenceStream() throws IOException {
 			String line;
 			String lastLine ="";
 			String buffer="";
 			while((line = getInputStream().readLine())!=null) {
 				line=line.replaceAll("[\t ]+"," ").trim();
-				
+
 				if(!buffer.trim().equals(""))
 					if((line.startsWith("@") || line.startsWith("#")) && !lastLine.startsWith("@") && !lastLine.startsWith("#")) { //!buffer.matches("@[^\n]*\n?$")) {
 						for (Module m:modules) {
 							if(m.getMode()==Mode.CONLLRDF) m.getOutputStream().println(reorderTTLBuffer(buffer, m.getCols()));
 							if(m.getMode()==Mode.DEBUG) System.err.println(colorTTL(reorderTTLBuffer(buffer, m.getCols())));
 							if(m.getMode()==Mode.CONLL) {
-								if (m.getCols().size() < 1) 
-									throw new IOException("-conll argument needs at least one COL to export!");
+								if (m.getCols().size() < 1) {// no column args supplied
+									LOG.info("No column names in cmd args, searching rdf comments..");
+									List<String> conllColumns = findColumnNamesInRDFBuffer(buffer);
+									if (conllColumns.size()>0) {
+										LOG.info("Using #global.comments from rdf");
+										m.setCols(conllColumns);
+									} else {
+										LOG.info("Trying conll columns now..");
+										conllColumns = CoNLL2RDF.findFieldsFromComments(new BufferedReader(new StringReader(buffer.trim())), 1);
+										if (conllColumns.size()>0) {
+											m.setCols(conllColumns);
+										}
+									}
+								}
+								if (m.getCols().size() < 1) {
+									LOG.info("Supply column names some way! (-conll arg, global.columns or rdf comments");
+								}
 								else
 									printSparql(buffer, columnsAsSelect(m.getCols()), new OutputStreamWriter(m.getOutputStream()));
 							}

--- a/src/org/acoli/conll/rdf/CoNLLStreamExtractor.java
+++ b/src/org/acoli/conll/rdf/CoNLLStreamExtractor.java
@@ -161,7 +161,13 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 
 	}
 
-	Model injectSentenceComments(Model m, ArrayList<String> comments) {
+	/**
+	 * Adds a list of conll comments to a sentence model as a rdfs:comment property separated by escaped newlines.
+	 * @param model a RDF Model representing a sentence
+	 * @param comments a list of single line comments
+	 * @return the updated model
+	 */
+	private Model injectSentenceComments(Model model, ArrayList<String> comments) {
         LOG.debug("Injecting comments.");
         // alternative to ParameterizeSparqlString: UpdateQuery
         ParameterizedSparqlString s = new ParameterizedSparqlString();
@@ -171,8 +177,8 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
                 +"WHERE { ?node a nif:Sentence . }");
         s.setLiteral("comment", String.join("\\n", comments));
 
-        UpdateAction.execute(s.asUpdate(), m);
-        return m;
+        UpdateAction.execute(s.asUpdate(), model);
+        return model;
 
     }
 

--- a/src/org/acoli/conll/rdf/CoNLLStreamExtractor.java
+++ b/src/org/acoli/conll/rdf/CoNLLStreamExtractor.java
@@ -230,7 +230,7 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 			inputStream.mark(readAheadLimit);
 
 			String peekedLine;
-			while ((peekedLine = inputStream.readLine()) != null && m <= maxLinesToSearch) {
+			while ((peekedLine = inputStream.readLine()) != null && m < maxLinesToSearch) {
 				m++;
 				meanByteSizeOfLine = ((meanByteSizeOfLine * (m - 1)) + peekedLine.length()) / m;
 				LOG.debug("Mean Byte size: " + meanByteSizeOfLine);
@@ -295,7 +295,7 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 			select=select+" "+argv[i++]; // because queries may be parsed by the shell (Cygwin)
 
 		if (fields.size() == 0) { // might be conllu plus, we check the first line for col names.
-			findFieldsFromComments(inputStream, fields, 10);
+			findFieldsFromComments(inputStream, fields, 1);
 		}
 
 

--- a/src/org/acoli/conll/rdf/CoNLLStreamExtractor.java
+++ b/src/org/acoli/conll/rdf/CoNLLStreamExtractor.java
@@ -112,7 +112,7 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 		for(String line = ""; line !=null; line=in.readLine()) {
 			if(line.contains("#")) {
 				out.write(line.replaceAll("^[^#]*#", "#") + "\n");
-				comments.add(line.replaceAll("^[^#]*#", "#"));
+				comments.add(line.replaceAll("^[^#]*#", ""));
 			}
 			line=line.replaceAll("<[\\/]?[psPS]( [^>]*>|>)","").trim(); // in this way, we can also read sketch engine data and split at s and p elements
 			if(!(line.matches("^<[^>]*>$")))							// but we skip all other XML elements, as used by Sketch Engine or TreeTagger chunker


### PR DESCRIPTION
# Arbitrary CoNLL comments
This implements metadata support for CoNLL when transforming to CoNLL-RDF. All comments in the CoNLL format that are lead by a hashmark will be written to the rdf graph as a rdfs:comment property of the sentence head node.

For example, this: 
```
# this is a comment
1       This
2       is
3       a
4       sentence
5       .
```
will result in this CoNLL-RDF:
```
# this is a comment
@prefix :      <https://example.com/> .
@prefix powla: <http://purl.org/powla/powla.owl#> .
@prefix terms: <http://purl.org/acoli/open-ie/> .
@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix conll: <http://ufal.mff.cuni.cz/conll2009-st/task-description.html#> .
@prefix x:     <http://purl.org/acoli/conll-rdf/xml#> .
@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
@prefix nif:   <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> .

:s1_1   a             nif:Word ;
        nif:nextWord  :s1_2 ;
        conll:HEAD    :s1_0 ;
        conll:ID      "1" ;
        conll:WORD    "This" .

:s1_4   a             nif:Word ;
        nif:nextWord  :s1_5 ;
        conll:HEAD    :s1_0 ;
        conll:ID      "4" ;
        conll:WORD    "sentence" .

:s1_2   a             nif:Word ;
        nif:nextWord  :s1_3 ;
        conll:HEAD    :s1_0 ;
        conll:ID      "2" ;
        conll:WORD    "is" .

:s1_0   a             nif:Sentence ;
        rdfs:comment  " this is a comment" .

:s1_5   a           nif:Word ;
        conll:HEAD  :s1_0 ;
        conll:ID    "5" ;
        conll:WORD  "." .

:s1_3   a             nif:Word ;
        nif:nextWord  :s1_4 ;
        conll:HEAD    :s1_0 ;
        conll:ID      "3" ;
        conll:WORD    "a" .
```
Also note, that we still directly transport any hashmark-lead comments to the CoNLL-RDF for backwards compartability. Also, when exporting CoNLL with the CoNLLRDFFormatter, we will write a `global.columns` comment to the first line of each sentence to improve ease of handling when reusing the CoNLLStreamExtractor, see below.

# CoNLL-U Plus support 
In addition to the general metadata support, we now support automatic column setting with the new [CoNLL-U Plus Format](https://universaldependencies.org/ext-format.html)

If the user does not supply any column names when calling the `CoNLLStreamExtractor`, we will try to find a `global.columns` comment in ONLY the first line and, if present, will use this as column names. Also, if using the CoNLLRDFFormatter to write conll again, we will search both raw conll comments and the rdfs:comment property for such a `global.columns` comment, IF the user did not provide column names themselves. They overwrite each other with following priority: -conll ARGS > rdfs:comment > raw conll comment.
