### PR TITLE
Restructure the Readme, Update the usage section and move it to doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 
 # conll-rdf
 
-tool package for converting between formats of annotated linguistic corpora. (e.g. `.conll` files into conll-rdf (`.ttl`) and back.) We support a variety of CoNLL formats.
+tool package for converting between formats of annotated linguistic corpora. (e.g. `.conll` files into conll-rdf (`.ttl`) and back.)  
+We support a variety of CoNLL formats.  
 conll-rdf consists of a number of java modules which can be stacked to construct a data processing pipeline. 
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ All relevant classes are in [src/](./src/org/acoli/conll/rdf). Sample scripts in
 
 IMPORTANT USAGE HINT: All given data is parsed sentence-wise (if applicable). Meaning that for CoNLL data as input a newline is considered as a sentence boundary marker (in regard to the CoNLL data model). The ID column (if present) must contain sentence internal IDs (if this is not the case this column must be renamed before conversion/parsing) - if no such column is provided sentence internal IDs will be generated. Please refer to the paper mentioned below under Reference.
 
+### CoNLLRDFManager
+`CoNLLRDFManager` processes a pipeline provided as JSON.
+Synopsis: `CoNLLRDFManager -c [JSON-config]`
+* `-c [JSON-config]` (required): provide the path to a json-file.
+
 ### CoNLLStreamExtractor
 
 `CoNLLStreamExtractor` expects CoNLL from `stdin` and writes conll-rdf to `stdout`.  

--- a/README.md
+++ b/README.md
@@ -70,8 +70,7 @@ IMPORTANT USAGE HINT: All given data is parsed sentence-wise (if applicable). Me
 
 ### CoNLLStreamExtractor
 
-
-`CoNLLStreamExtractor` expects CoNLL from `stdin` and writes conll-rdf to `stdout`.   
+`CoNLLStreamExtractor` expects CoNLL from `stdin` and writes conll-rdf to `stdout`.  
 Synopsis: ```CoNLLStreamExtractor baseURI FIELD1[.. FIELDn] [-u SPARQL_UPDATE1..m] [-s SPARQL_SELECT]```
 
 * `baseURI` (required): ideally a resolvable URL to adhere to the five stars of LOD.
@@ -79,58 +78,73 @@ Synopsis: ```CoNLLStreamExtractor baseURI FIELD1[.. FIELDn] [-u SPARQL_UPDATE1..
        * this option overrides any column names specified in the comments of the input.
        * If no fields are provided here, we check the first line of the input for a `# global.columns = [FIELDS]` comment, as specified in [CoNLL-U Plus](https://universaldependencies.org/ext-format.html).
 	* note that `CoNLLStreamExtractor` will not check if the fields match the input. Make sure the number of fields matches the number of columns of your CoNLL input. 
-* `[-u SPARQL_UPDATE1 .. m]`: execute sparql updates before writing to stdout.
-       * **The SPARQL_UPDATE parameter is DEPRECATED - please use CoNLLRDFUpdater instead!**
-       * can be followed by an optional integer x in {}-parentheses = number of repetitions e.g. `-u examples/sparql/remove-ID.sparql{5}`. Will repeat the update x times or until model stops changing.
-		* `{u}` for unlimited will repeat 999 times.
-* `[-s SPARQL_SELECT]`: Optional select statement for generating TSV output.
+* `[-u SPARQL_UPDATE1 .. m]` (**deprecated**): It is recommended you use`CoNLLRDFUpdater -custom -updates [SPARQL_UPDATE1 .. m]` instead.
+* `[-s SPARQL_SELECT]` (optional): select query for generating TSV output.
 
 ### CoNLLRDFUpdater
 
-
 `CoNLLRDFUpdater` expects conll-rdf from `stdin` and writes conll-rdf to `stdout`. It is designed for updating existing conll-rdf files and is able to load external ontologies or RDF data into separate Graphs during runtime. This is especially useful for linking CoNLL-RDF files to other ontologies.  
-Synopsis: ```CoNLLRDFUpdater -custom [-model URI [GRAPH]]* -updates [UPDATE]+```
+Synopsis:
+```
+CoNLLRDFUpdater [-loglevel LEVEL] [-threads T] [-lookahead N] [-lookback N]
+	[-custom
+		[-model URI [GRAPH]]*
+		[-graphsout DIR [SENT_ID]] [-triplesout DIR [SENT_ID]]
+		-updates [UPDATE]]
+```
+#### optimisation:
+* `loglevel LEVEL`: set log level to LEVEL
+* `threads T`: use at most T threads
+* `lookahead N`: cache N following sentences in lookahead graph
+* `lookback N`: cache N preceeding sentences in lookback graph
+             default: half of available logical processor cores
 
-* `-custom [-model URI [GRAPH]]* -updates [UPDATE]+` : for executing customized set of SPARQL updates
-	* `-updates [SPARQL_UPDATE1 .. m]` (required): List of paths to SPARQL scripts. Will be executed before writing to stdout.
-		* can be followed by an optional integer x in {}-parentheses = number of repetitions e.g. `-updates examples/sparql/remove-ID.sparql{5}`. Will repeat the update x times or until model stops changing.
-			* `{u}` for unlimited will repeat up to 999 times.
-	* See [examples/](./examples) for reference. 
-	* `-model URI [GRAPH]` (optional): List of external resources to be loaded before updating.
-		* `URI` (required): Path to external ontology. Will be pre-loaded by the Updater and available for the whole runtime.
-		* `GRAPH` (optional): GRAPH into which the ontology should be loaded. If empty: `URI` is used as graph name.
+#### common:
+* `custom`: required command-line argument for any of the arguments below
+* `updates [SPARQL_UPDATE]+`: applies updates to the CoNLL-RDF.
+  * `[SPARQL_UPDATE]` (required): List of paths to SPARQL Updates to apply.
+	* `{x}` (optional for each): max. number of times to apply the update for.  
+	e.g. `-updates examples/sparql/remove-ID.sparql{5}`. Will repeat the update x times or until model stops changing.
+	* `{u}` (optional): for unlimited will repeat up to 999 times.
+  * Hint: `SPARQL_UPDATE` can be an update-query as a String. If this String is passed on by BASH/SHELL the String must be enclosed in \`-quotation marks (will be otherwise split into several arguments)!
+* `model URI [GRAPH]` (optional): List of external resources to be loaded before updating.
+	* `URI` (required): Path to external ontology. Will be pre-loaded by the Updater and available for the whole runtime.
+	* `GRAPH` (optional): GRAPH into which the ontology should be loaded. If empty: `URI` is used as graph name.
 
-Hint: The -updates parameter can take a SPARQL-update-query as a String. If this String is passed on by BASH/SHELL the String must be enclosed in \`-quotation marks (will be otherwise split into several arguments)!
+#### graphs:
+* `graphsout DIR [SENT_ID]`: create .dot graph files for sentence models
+  * `DIR` (required): Path of the directory to output the graphs to.
+  * `SENT_ID` (optional): IDs of sentences to visualize.  
+  default: first sentence only
+* `triplesout`: same as graphsout but write N-TRIPLES for text debug instead.  
+otherwise identical to `graphsout`.
 
 ### CoNLLRDFFormatter
 
 `CoNLLRDFFormatter` expects conll-rdf in `.ttl` and writes to different formats. Can also visualize your data.  
 Synopsis: ```CoNLLRDFFormatter [-rdf [COLS]] [-debug] [-grammar] [-semantics] [-conll COLS] [-sparqltsv SPARQL]```
 
-* `-rdf` (default): writes canonical conll-rdf as .ttl.
-* `-conll [COLS]`: writes .conll of specified columns in order of arguments. 
+* `rdf` (default): writes canonical conll-rdf as .ttl.
+* `conll [COLS]`: writes .conll of specified columns in order of arguments. 
   * If no cols are provided, we assume the original conll was [CoNLL-U Plus](https://universaldependencies.org/ext-format.html).
     We first search for a `rdfs:comment` property with a `global.columns` comment, then the raw conll-like comments.
   * Note that we will overwrite any `global.columns` comments with the new column names, so you may read them with the `CoNLLStreamExtractor` again right away.
-* `-debug`: writes highlighted .ttl to `stderr`, e.g. highlighting triples representing conll columns or sentence structure differently. 
+* `sparqltsv [SPARQL-SELECT-FILE]`: writes TSV to `stdout` based on a given sparql select query.
+  * column sequence is based on selector sequence within the sparql query.
+  * writes the column names as a comment line before every sentence.
+* `debug`: writes highlighted .ttl to `stderr`, e.g. highlighting triples representing conll columns or sentence structure differently. 
   * does not work in combination with `-conll`.
   * to add custom highlighting you can add rules to `colorTTL(String buffer)` in `CoNLLRDFFormatter.java`. Don't forget to recompile!
-  
 > ![-debug](doc/img/conllrdfformatter-debug.png)  
 > Example from universal dependencies.
 
-* `-grammar`: writes conll data structure in tree-like format to `stdout`.
+* `grammar`: writes conll data structure in tree-like format to `stdout`.
   * Indents are based on `conll:HEAD` relation.
   * `/` resp. `\` are pointing in direction of `conll:HEAD`.
-
 > ![-grammar](doc/img/conllrdfformatter-grammar.png)  
 > Example from universal dependencies.
-
-* `-sparqltsv [SPARQL-SELECT-FILE]`: writes TSV to `stdout` based on a given sparql select query.
-  * column sequence is based on selector sequence within the sparql query.
-  * writes the column names as a comment line before every sentence.
-
-* `-semantics`: seperate visualization of object properties of `conll:WORD` using `terms:` namespace, useful for visualizing knowledge graphs. **`EXPERIMENTAL`**
+> 
+* `semantics`: seperate visualization of object properties of `conll:WORD` using `terms:` namespace, useful for visualizing knowledge graphs. **`EXPERIMENTAL`**
 
 ### CoNLLRDFAnnotator
 

--- a/README.md
+++ b/README.md
@@ -70,15 +70,14 @@ IMPORTANT USAGE HINT: All given data is parsed sentence-wise (if applicable). Me
 Synopsis: ```CoNLLStreamExtractor baseURI FIELD1[.. FIELDn] [-u SPARQL_UPDATE1..m] [-s SPARQL_SELECT]```
 
 * `baseURI` (required): ideally a resolvable URL to adhere to the five stars of LOD.
-* `FIELD1[.. FIELDn]`: name each column of input conll. 
-	* at least one column name is required.
-	* note that `CoNLLStreamExtractor` will not check the number of columns. Make sure the list of fields match the number of columns of your CoNLL input. 
-	* In case input is [CoNLL-U Plus](https://universaldependencies.org/ext-format.html), we read the fieldnames from the `# global.comments = [FIELDS]` comment.
-	This comment MUST be in the first line.
-* `[-u SPARQL_UPDATE1 .. m]`: execute sparql updates before writing to stdout. 
-	* can be followed by an optional integer x in {}-parentheses = number of repetitions e.g. `-u examples/sparql/remove-ID.sparql{5}`. Will repeat the update x times or until model stops changing.
+* `FIELD1[.. FIELDn]`: name each column of input conll.
+       * this option overrides any column names specified in the comments of the input.
+       * If no fields are provided here, we check the first line of the input for a `# global.columns = [FIELDS]` comment, as specified in [CoNLL-U Plus](https://universaldependencies.org/ext-format.html).
+	* note that `CoNLLStreamExtractor` will not check if the fields match the input. Make sure the number of fields matches the number of columns of your CoNLL input. 
+* `[-u SPARQL_UPDATE1 .. m]`: execute sparql updates before writing to stdout.
+       * **The SPARQL_UPDATE parameter is DEPRECATED - please use CoNLLRDFUpdater instead!**
+       * can be followed by an optional integer x in {}-parentheses = number of repetitions e.g. `-u examples/sparql/remove-ID.sparql{5}`. Will repeat the update x times or until model stops changing.
 		* `{u}` for unlimited will repeat 999 times.
-	* See [examples/](./examples) for reference. 
 * `[-s SPARQL_SELECT]`: Optional select statement for generating TSV output.
 
 ### CoNLLRDFUpdater
@@ -89,13 +88,14 @@ Synopsis: ```CoNLLRDFUpdater -custom [-model URI [GRAPH]]* -updates [UPDATE]+```
 
 * `-custom [-model URI [GRAPH]]* -updates [UPDATE]+` : for executing customized set of SPARQL updates
 	* `-updates [SPARQL_UPDATE1 .. m]` (required): List of paths to SPARQL scripts. Will be executed before writing to stdout.
-		* can be followed by an optional integer x in {}-parentheses = number of repetitions e.g. `-u examples/sparql/remove-ID.sparql{5}`. Will repeat the update x times or until model stops changing.
-			* `{u}` for unlimited will repeat 999 times.
+		* can be followed by an optional integer x in {}-parentheses = number of repetitions e.g. `-updates examples/sparql/remove-ID.sparql{5}`. Will repeat the update x times or until model stops changing.
+			* `{u}` for unlimited will repeat up to 999 times.
+	* See [examples/](./examples) for reference. 
 	* `-model URI [GRAPH]` (optional): List of external resources to be loaded before updating.
 		* `URI` (required): Path to external ontology. Will be pre-loaded by the Updater and available for the whole runtime.
 		* `GRAPH` (optional): GRAPH into which the ontology should be loaded. If empty: `URI` is used as graph name.
 
-Hint: The -updates parameter can take a SPARQL-update-query as a String. If this String is passed on by BASH/SHELL the String must be enclosed in \`-qutoation marks (will be otherwise split into several arguments)!
+Hint: The -updates parameter can take a SPARQL-update-query as a String. If this String is passed on by BASH/SHELL the String must be enclosed in \`-quotation marks (will be otherwise split into several arguments)!
 
 ### CoNLLRDFFormatter
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ We also provide a [hands-on tutorial](./examples) which comes with prepared scri
 ### Installing
 
 
-java is required, use `java -version` to check if you have java installed.
+java is required, use `java -version` to check if Java is installed.
 (Java version 8 or 9 is required for logging with log4j)
+
+javac, the JDK compiler, is required to compile the source.  
+Check with `javac -version` if you have it installed.
 
 Note: If you prefer using OpenJDK instead of Oracle Java, it might be necessary to install openjfx. (Thanks to Francesco Mambrini for finding out!)
 ```shell

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 
 # conll-rdf
 
-tool package for converting .conll files into conll-rdf and back. We support a variety of CoNLL formats. conll-rdf consists of a number of java modules which can be stacked to construct a data processing pipeline. 
+tool package for converting between formats of annotated linguistic corpora. (e.g. `.conll` files into conll-rdf (`.ttl`) and back.) We support a variety of CoNLL formats.
+conll-rdf consists of a number of java modules which can be stacked to construct a data processing pipeline. 
 
 ## Getting Started
 


### PR DESCRIPTION
- [x] Update the sections describing the use of the StreamExtractor (mentioning the deprecation of the -u functionality), and the RDFUpdater.
- [x] Rewrite several passages to help with readability and correct some typos.
- [ ] Move the more extensive documentation into a place like doc/readme.md