### PR TITLE
WIP: Tutorial for using json configs with the RDFManager-class

### DIFF
--- a/examples/analyze-ud.json
+++ b/examples/analyze-ud.json
@@ -1,0 +1,26 @@
+{
+"input" : "data/ud/UD_English-master/en-ud-dev.conllu.gz"
+, "output" : "System.out"
+, "pipeline" : [ 
+
+	{ "class" : "CoNLLStreamExtractor",
+		"baseURI" : "https://github.com/UniversalDependencies/UD_English#",
+		"columns" : ["IGNORE", "WORD", "IGNORE", "UPOS", "IGNORE", "IGNORE", "HEAD", "EDGE", "IGNORE", "IGNORE"]
+	},
+	
+	{ "class" : "CoNLLRDFUpdater"
+		, "updates" : [
+			{"path":"examples/sparql/remove-IGNORE.sparql", "iter":"1"},
+			{"path":"examples/sparql/analyze/UPOS-to-POSsynt.sparql", "iter":"1"},
+			{"path":"examples/sparql/analyze/EDGE-to-POSsynt.sparql", "iter":"1"},
+			{"path":"examples/sparql/analyze/consolidate-POSsynt.sparql", "iter":"1"}
+		]
+	} ,
+	
+	{ "class" : "CoNLLRDFFormatter"
+		, "modules" : [
+			{"mode":"SPARQLTSV", "select": "examples/sparql/analyze/eval-POSsynt.sparql"}
+		]
+	}
+]
+}

--- a/examples/convert-ud.json
+++ b/examples/convert-ud.json
@@ -1,0 +1,35 @@
+// CoNLL-RDF EXAMPLE: convert a corpus to RDF
+// 
+// example pipeline for the RDF edition of Universal Dependencies (UD) corpora 
+// cf. link-ud.sh for linking such data
+//
+// 1. read
+//for file in `find data/ud -name '\.conllu.gz$'`; do \
+//	echo $file; 
+//	filename=$(basename "$file"); 
+//	tmp=UD_${file#*UD_}; 
+//	lang=${tmp%-master/*}; 
+//	gunzip -c $file | \
+// 2. parse UD data to RDF
+//	CoNLLStreamExtractor https://github.com/UniversalDependencies/$lang#
+// 3. format
+//	$* > $DATA/ud/UD_English-master/$filename.ttl \ # nicht abhängig von lang?
+//; done
+//
+{
+"input" : "data/ud/UD_English-master/en-ud-dev.conllu.gz"
+, "output" : "data/ud/UD_English-master/en-ud-dev.ttl"
+, "pipeline" : [ 
+
+	{ "class" : "CoNLLStreamExtractor",
+		"baseURI" : "https://github.com/UniversalDependencies/UD_English#",
+		"columns" : ["ID", "WORD", "LEMMA", "UPOS", "POS", "FEAT", "HEAD", "EDGE", "DEPS", "MISC"]
+	},
+	
+	{ "class" : "CoNLLRDFFormatter",
+		"modules" : [
+				{"mode":"RDF", "columns": ["ID", "WORD", "LEMMA", "UPOS", "POS", "FEAT", "HEAD", "EDGE", "DEPS", "MISC"]}
+		]
+	}
+]
+}

--- a/json-tutorial.md
+++ b/json-tutorial.md
@@ -1,0 +1,103 @@
+#CoNLL-RDF Pipelines with Json
+CoNLL-RDF tools can be called from the shell individually and chained with pipes, but there is a better method.
+##CoNLLRDFManager
+You can run the CoNLL-RDF_Manager just like the other Java-classes.
+```bash
+./run.sh CoNLLRDFManager -c examples/analyze-ud.json
+```
+But unlike the other tools, the configuration isn't done in the shell.  
+The entire Pipeline is configured in the json document that we pass along with the `-c` flag.
+
+Let's take a look at the structure:
+```json
+{
+"input" : "data/ud/UD_English-master/en-ud-dev.conllu.gz"
+, "output" : "System.out"
+, "pipeline" : [ 
+
+	{ "class" : "CoNLLStreamExtractor",
+		"baseURI" : "https://github.com/UniversalDependencies/UD_English#",
+		"columns" : ["IGNORE", "WORD", "IGNORE", "UPOS", "IGNORE", "IGNORE", "HEAD", "EDGE", "IGNORE", "IGNORE"]
+	},
+	
+	{ "class" : "CoNLLRDFUpdater"
+		, "updates" : [
+			{"path":"examples/sparql/remove-IGNORE.sparql", "iter":"1"},
+			{"path":"examples/sparql/analyze/UPOS-to-POSsynt.sparql", "iter":"1"},
+			{"path":"examples/sparql/analyze/EDGE-to-POSsynt.sparql", "iter":"1"},
+			{"path":"examples/sparql/analyze/consolidate-POSsynt.sparql", "iter":"1"}
+		]
+	} ,
+	
+	{ "class" : "CoNLLRDFFormatter"
+		, "modules" : [
+			{"mode":"SPARQLTSV", "select": "examples/sparql/analyze/eval-POSsynt.sparql"}
+		]
+	}
+]
+}
+```
+The outermost struct is a dictionary with the keys "input", "output", "pipeline".
+
+"input" stores a literal that is the path to a .connlu.gz file.  
+The tool automatically decompresses .connlu.gz files before passing the stream to the first class in the pipeline.
+
+"output" stores a literal that is "System.out".  
+System.out doesn't represent a file, but a stream to the shell. The last tool in the pipeline will stream its output to the shell.
+
+"pipeline" stores a list of dicts. The order within it is the order in which the tools are chained.
+
+Each entry in the list contains the key "class", which stores the name of the class to be used. The remaining keys vary depending on this class.
+
+
+```json
+{
+"input" : "PATH"
+, "output" : "System.out"
+, "pipeline" : [ 
+
+	{ "class" : "CoNLLStreamExtractor",
+		"baseURI" : "URI",
+		"columns" : ["COL1", "COL2"]
+	},
+	
+	{ "class" : "CoNLLRDFUpdater"
+		, "updates" : [
+			{"path":"PATH", "iter":"1"}, 
+			{"path":"sparql/test.sparql", "iter":"*"}
+		]
+		, "models" : [
+			{"source":"URI", "graph":"URI"},
+			{"source":"URI", "graph":"URI"}
+		]
+		//OPTIONAL for cross-sentence processing
+		//, "lookahead" : "0" 
+		//, "lookback" : "0" 
+		//OPTIONAL for debugging
+		//, "threads" : "default" 
+		//, "graphsoutDIR" : "PATH"
+		//, "graphsoutSNT" : ["s1","s5"]
+		//, "triplesoutDIR" : "PATH"
+		//, "triplesoutSNT" : ["s1","s5"]
+	} ,
+	
+	{ "class" : "CoNLLRDFFormatter",
+		// must be called LAST in pipeline --> else, ERROR
+		// multiple outputs can be generated simultaneously. (but need distinct outstreams, else ERROR)
+		// if only one mode w/o specific outstream, use default output.
+		// if NO mode: use "RDF" + default output
+		"modules" : [
+				// DEBUG always writes to System.err
+				{"mode":"DEBUG"}
+				, {"mode":"RDF", "columns": ["COL1", "COL2"], "output":"PATH"}
+				, {"mode":"CONLL", "columns": ["COL1", "COL2"], "output":"PATH"}
+				, {"mode":"SPARQLTSV", "select": "PATH", "output":"PATH"}
+				// GRAMMAR and SEMANTICS can be combined
+				, {"mode":"GRAMMAR", "output":"PATH"}
+				, {"mode":"SEMANTICS", "output":"PATH"}
+				, {"mode":"GRAMMAR+SEMANTICS", "output":"PATH"}
+		]
+	}
+]
+}
+```

--- a/json-tutorial.md
+++ b/json-tutorial.md
@@ -5,7 +5,7 @@ You can run the CoNLL-RDF Manager from the shell, just like the other Java-class
 ```bash
 ./run.sh CoNLLRDFManager -c examples/analyze-ud.json
 ```
-The Class takes a single argument: `-c`, followed by the path to the JSON-formatted configuration file.
+The Class takes a single argument: `-c`, followed by the path to the `.json` configuration file.
 
 Let's take a look at the structure:
 ```json
@@ -19,7 +19,7 @@ The entire configuration is stored in the `.json` file as an Object with the Key
 ```json
 "input" : "data/ud/UD_English-master/en-ud-dev.conllu.gz"
 ```
-In this case `"input"` is paired with the path to a `.connlu.gz` file.  
+In `"input"` we store the path to a `.connlu.gz` file.  
 The tool recognizes the file-extension and decompresses the file before passing the stream to the first class in the pipeline.
 ```json
 "output" : "System.out"
@@ -58,7 +58,8 @@ Each Object in the Array corresponds to a class in the Pipeline, and contains th
 "baseURI" : "https://github.com/UniversalDependencies/UD_English#",  
 "columns" : ["IGNORE", "WORD", "IGNORE", "UPOS", "IGNORE", "IGNORE", "HEAD", "EDGE", "IGNORE", "IGNORE"]
 ```
-
+As our input is CoNLLU, the first Class needs to be the Stream Extractor.  
+We provide a base-URI and an Array of column names.
 ```json
 "class" : "CoNLLRDFUpdater",
 "updates" : [
@@ -68,63 +69,14 @@ Each Object in the Array corresponds to a class in the Pipeline, and contains th
   {"path":"examples/sparql/analyze/consolidate-POSsynt.sparql", "iter":"1"}
 ]
 ```
-
+The resulting RDF is passed to the Updater. Several SPARQL Update Queries are applied to strip the ignored data, and to compare the values in the UPOS and EDGE columns.
 ```json
 "class" : "CoNLLRDFFormatter",
 "modules" : [
   {"mode":"SPARQLTSV", "select": "examples/sparql/analyze/eval-POSsynt.sparql"}
 ] 
 ```
+Lastly the RDF is passed to the Formatter, which is configured to output the result of a SPARQL Select Query as Tab-seperated Values.  
+The output is streamed to the console.
+
 See [the template](src/template.conf.json) for a full list of options, and the documentation for in-depth explanations of each.
-
-```yaml
-{
-"input" : "PATH"
-, "output" : "System.out"
-, "pipeline" : [ 
-
-	{ "class" : "CoNLLStreamExtractor",
-		"baseURI" : "URI",
-		"columns" : ["COL1", "COL2"]
-	},
-	
-	{ "class" : "CoNLLRDFUpdater"
-		, "updates" : [
-			{"path":"PATH", "iter":"1"}, 
-			{"path":"sparql/test.sparql", "iter":"*"}
-		]
-		, "models" : [
-			{"source":"URI", "graph":"URI"},
-			{"source":"URI", "graph":"URI"}
-		]
-		#OPTIONAL for cross-sentence processing
-		#, "lookahead" : "0" 
-		#, "lookback" : "0" 
-		#OPTIONAL for debugging
-		#, "threads" : "default" 
-		#, "graphsoutDIR" : "PATH"
-		#, "graphsoutSNT" : ["s1","s5"]
-		#, "triplesoutDIR" : "PATH"
-		#, "triplesoutSNT" : ["s1","s5"]
-	} ,
-	
-	{ "class" : "CoNLLRDFFormatter",
-		# must be called LAST in pipeline --> else, ERROR
-		# multiple outputs can be generated simultaneously. (but need distinct outstreams, else ERROR)
-		# if only one mode w/o specific outstream, use default output.
-		# if NO mode: use "RDF" + default output
-		"modules" : [
-				# DEBUG always writes to System.err
-				{"mode":"DEBUG"}
-				, {"mode":"RDF", "columns": ["COL1", "COL2"], "output":"PATH"}
-				, {"mode":"CONLL", "columns": ["COL1", "COL2"], "output":"PATH"}
-				, {"mode":"SPARQLTSV", "select": "PATH", "output":"PATH"}
-				# GRAMMAR and SEMANTICS can be combined
-				, {"mode":"GRAMMAR", "output":"PATH"}
-				, {"mode":"SEMANTICS", "output":"PATH"}
-				, {"mode":"GRAMMAR+SEMANTICS", "output":"PATH"}
-		]
-	}
-]
-}
-```

--- a/json-tutorial.md
+++ b/json-tutorial.md
@@ -1,67 +1,83 @@
-# CoNLL-RDF Pipelines with Json
-CoNLL-RDF tools can be called from the shell individually and chained with pipes, but there is a better method.
-## CoNLLRDFManager
-You can run the CoNLL-RDF_Manager just like the other Java-classes.
+# CoNLL-RDF Manager: CoNLL-RDF Pipelines with JSON
+One of the recommended ways to run a CoNLL-RDF pipeline is to use the CoNLL-RDF Manager.
+
+You can run the CoNLL-RDF Manager from the shell, just like the other Java-classes.
 ```bash
 ./run.sh CoNLLRDFManager -c examples/analyze-ud.json
 ```
-But unlike the other tools, the configuration isn't done in the shell.  
-The entire Pipeline is configured in the json document that we pass along with the `-c` flag.
+The Class takes a single argument: `-c`, followed by the path to the JSON-formatted configuration file.
 
 Let's take a look at the structure:
 ```json
 {
-"input" : ""
-, "output" : ""
-, "pipeline" : [ ]
+"input" : "",
+"output" : "",
+"pipeline" : [ ]
 }
 ```
-The config-json is a dictionary with the keys "input", "output" and "pipeline".
+The entire configuration is stored in the `.json` file as an Object with the Keys `"input"`, `"output"` and `"pipeline"`.
 ```json
 "input" : "data/ud/UD_English-master/en-ud-dev.conllu.gz"
 ```
-"input" in this case has the path to a .connlu.gz file.  
+In this case `"input"` is paired with the path to a `.connlu.gz` file.  
 The tool recognizes the file-extension and decompresses the file before passing the stream to the first class in the pipeline.
 ```json
 "output" : "System.out"
 ```
-"output" has the literal "System.out".  
-System.out doesn't represent a file, but a stream to the shell. The last tool in the pipeline will stream its output to the shell.
+Here `"output"` is paired with the String `"System.out"`.  
+System.out is a string with a special meaning. It tells the CoNLL-RDF-Manager that the last tool in the pipeline should default to streaming its output to the shell.
 ```json
 "pipeline" : [
-	{ "class" : "CoNLLStreamExtractor", ... },
-	{ "class" : "CoNLLRDFUpdater", ... },
-	{ "class" : "CoNLLRDFFormatter", ... }
+  { "class" : "CoNLLStreamExtractor", "..." },
+  { "class" : "CoNLLRDFUpdater", "..." },
+  { "class" : "CoNLLRDFFormatter", "..." }
 ]
 ```
-"pipeline" stores a list of dicts. The order within the list is the order in which the tools are chained.
+The Key `"pipeline"` stores an Array of Objects. The order within the Array is the order in which the tools are chained.
 ```json
-	{ "class" : "CoNLLStreamExtractor",
-		"baseURI" : "",
-		"columns" : [ ]
-	},
-	
-	{ "class" : "CoNLLRDFUpdater",
-		"updates" : [
-			{"path":"", "iter":"1"},
-			...
-		]
-	} ,
-	
-	{ "class" : "CoNLLRDFFormatter"
-		, "modules" : [
-			{"mode":"SPARQLTSV", "select": "examples/sparql/analyze/eval-POSsynt.sparql"}
-		]
-	}
-]
+{ "class" : "CoNLLStreamExtractor"
+  , "baseURI" : ""
+  , "columns" : [ ]
+},
+
+{ "class" : "CoNLLRDFUpdater"
+  , "updates" : [
+      {"path":"", "iter":"1"},
+	]
+} ,
+
+{ "class" : "CoNLLRDFFormatter"
+  , "modules" : [
+      {"mode":"SPARQLTSV", "select": "examples/sparql/analyze/eval-POSsynt.sparql"}
+	]
 }
 ```
-
-Each entry in the list contains the key "class", which stores the name of the class to be used. The remaining keys vary depending on the class.
-
-See [the template](src/template.conf.json) for more options.
+Each Object in the Array corresponds to a class in the Pipeline, and contains the Key `"class"`, which stores the name of the class. The remaining Keys are specific to the class.
+```json
+"class" : "CoNLLStreamExtractor",  
+"baseURI" : "https://github.com/UniversalDependencies/UD_English#",  
+"columns" : ["IGNORE", "WORD", "IGNORE", "UPOS", "IGNORE", "IGNORE", "HEAD", "EDGE", "IGNORE", "IGNORE"]
+```
 
 ```json
+"class" : "CoNLLRDFUpdater",
+"updates" : [
+  {"path":"examples/sparql/remove-IGNORE.sparql", "iter":"1"},
+  {"path":"examples/sparql/analyze/UPOS-to-POSsynt.sparql", "iter":"1"},
+  {"path":"examples/sparql/analyze/EDGE-to-POSsynt.sparql", "iter":"1"},
+  {"path":"examples/sparql/analyze/consolidate-POSsynt.sparql", "iter":"1"}
+]
+```
+
+```json
+"class" : "CoNLLRDFFormatter",
+"modules" : [
+  {"mode":"SPARQLTSV", "select": "examples/sparql/analyze/eval-POSsynt.sparql"}
+] 
+```
+See [the template](src/template.conf.json) for a full list of options, and the documentation for in-depth explanations of each.
+
+```yaml
 {
 "input" : "PATH"
 , "output" : "System.out"
@@ -81,29 +97,29 @@ See [the template](src/template.conf.json) for more options.
 			{"source":"URI", "graph":"URI"},
 			{"source":"URI", "graph":"URI"}
 		]
-		//OPTIONAL for cross-sentence processing
-		//, "lookahead" : "0" 
-		//, "lookback" : "0" 
-		//OPTIONAL for debugging
-		//, "threads" : "default" 
-		//, "graphsoutDIR" : "PATH"
-		//, "graphsoutSNT" : ["s1","s5"]
-		//, "triplesoutDIR" : "PATH"
-		//, "triplesoutSNT" : ["s1","s5"]
+		#OPTIONAL for cross-sentence processing
+		#, "lookahead" : "0" 
+		#, "lookback" : "0" 
+		#OPTIONAL for debugging
+		#, "threads" : "default" 
+		#, "graphsoutDIR" : "PATH"
+		#, "graphsoutSNT" : ["s1","s5"]
+		#, "triplesoutDIR" : "PATH"
+		#, "triplesoutSNT" : ["s1","s5"]
 	} ,
 	
 	{ "class" : "CoNLLRDFFormatter",
-		// must be called LAST in pipeline --> else, ERROR
-		// multiple outputs can be generated simultaneously. (but need distinct outstreams, else ERROR)
-		// if only one mode w/o specific outstream, use default output.
-		// if NO mode: use "RDF" + default output
+		# must be called LAST in pipeline --> else, ERROR
+		# multiple outputs can be generated simultaneously. (but need distinct outstreams, else ERROR)
+		# if only one mode w/o specific outstream, use default output.
+		# if NO mode: use "RDF" + default output
 		"modules" : [
-				// DEBUG always writes to System.err
+				# DEBUG always writes to System.err
 				{"mode":"DEBUG"}
 				, {"mode":"RDF", "columns": ["COL1", "COL2"], "output":"PATH"}
 				, {"mode":"CONLL", "columns": ["COL1", "COL2"], "output":"PATH"}
 				, {"mode":"SPARQLTSV", "select": "PATH", "output":"PATH"}
-				// GRAMMAR and SEMANTICS can be combined
+				# GRAMMAR and SEMANTICS can be combined
 				, {"mode":"GRAMMAR", "output":"PATH"}
 				, {"mode":"SEMANTICS", "output":"PATH"}
 				, {"mode":"GRAMMAR+SEMANTICS", "output":"PATH"}

--- a/json-tutorial.md
+++ b/json-tutorial.md
@@ -11,10 +11,23 @@ The entire Pipeline is configured in the json document that we pass along with t
 Let's take a look at the structure:
 ```json
 {
+```
+The outermost struct is a dictionary with the keys "input", "output", "pipeline".
+```json
 "input" : "data/ud/UD_English-master/en-ud-dev.conllu.gz"
+```
+"input" in this case has the path to a .connlu.gz file.  
+The tool recognizes the file-extension and decompresses the file before passing the stream to the first class in the pipeline.
+```json
 , "output" : "System.out"
-, "pipeline" : [ 
-
+```
+"output" has the literal "System.out".  
+System.out doesn't represent a file, but a stream to the shell. The last tool in the pipeline will stream its output to the shell.
+```json
+, "pipeline" : [
+```
+"pipeline" stores a list of dicts. The order within the list is the order in which the tools are chained.
+```json
 	{ "class" : "CoNLLStreamExtractor",
 		"baseURI" : "https://github.com/UniversalDependencies/UD_English#",
 		"columns" : ["IGNORE", "WORD", "IGNORE", "UPOS", "IGNORE", "IGNORE", "HEAD", "EDGE", "IGNORE", "IGNORE"]
@@ -37,18 +50,10 @@ Let's take a look at the structure:
 ]
 }
 ```
-The outermost struct is a dictionary with the keys "input", "output", "pipeline".
-
-"input" stores a literal that is the path to a .connlu.gz file.  
-The tool automatically decompresses .connlu.gz files before passing the stream to the first class in the pipeline.
-
-"output" stores a literal that is "System.out".  
-System.out doesn't represent a file, but a stream to the shell. The last tool in the pipeline will stream its output to the shell.
-
-"pipeline" stores a list of dicts. The order within it is the order in which the tools are chained.
 
 Each entry in the list contains the key "class", which stores the name of the class to be used. The remaining keys vary depending on this class.
 
+See [the template](src/template.conf.json) for more options.
 
 ```json
 {

--- a/json-tutorial.md
+++ b/json-tutorial.md
@@ -1,6 +1,6 @@
-#CoNLL-RDF Pipelines with Json
+# CoNLL-RDF Pipelines with Json
 CoNLL-RDF tools can be called from the shell individually and chained with pipes, but there is a better method.
-##CoNLLRDFManager
+## CoNLLRDFManager
 You can run the CoNLL-RDF_Manager just like the other Java-classes.
 ```bash
 ./run.sh CoNLLRDFManager -c examples/analyze-ud.json
@@ -11,34 +11,40 @@ The entire Pipeline is configured in the json document that we pass along with t
 Let's take a look at the structure:
 ```json
 {
+"input" : ""
+, "output" : ""
+, "pipeline" : [ ]
+}
 ```
-The outermost struct is a dictionary with the keys "input", "output", "pipeline".
+The config-json is a dictionary with the keys "input", "output" and "pipeline".
 ```json
 "input" : "data/ud/UD_English-master/en-ud-dev.conllu.gz"
 ```
 "input" in this case has the path to a .connlu.gz file.  
 The tool recognizes the file-extension and decompresses the file before passing the stream to the first class in the pipeline.
 ```json
-, "output" : "System.out"
+"output" : "System.out"
 ```
 "output" has the literal "System.out".  
 System.out doesn't represent a file, but a stream to the shell. The last tool in the pipeline will stream its output to the shell.
 ```json
-, "pipeline" : [
+"pipeline" : [
+	{ "class" : "CoNLLStreamExtractor", ... },
+	{ "class" : "CoNLLRDFUpdater", ... },
+	{ "class" : "CoNLLRDFFormatter", ... }
+]
 ```
 "pipeline" stores a list of dicts. The order within the list is the order in which the tools are chained.
 ```json
 	{ "class" : "CoNLLStreamExtractor",
-		"baseURI" : "https://github.com/UniversalDependencies/UD_English#",
-		"columns" : ["IGNORE", "WORD", "IGNORE", "UPOS", "IGNORE", "IGNORE", "HEAD", "EDGE", "IGNORE", "IGNORE"]
+		"baseURI" : "",
+		"columns" : [ ]
 	},
 	
-	{ "class" : "CoNLLRDFUpdater"
-		, "updates" : [
-			{"path":"examples/sparql/remove-IGNORE.sparql", "iter":"1"},
-			{"path":"examples/sparql/analyze/UPOS-to-POSsynt.sparql", "iter":"1"},
-			{"path":"examples/sparql/analyze/EDGE-to-POSsynt.sparql", "iter":"1"},
-			{"path":"examples/sparql/analyze/consolidate-POSsynt.sparql", "iter":"1"}
+	{ "class" : "CoNLLRDFUpdater",
+		"updates" : [
+			{"path":"", "iter":"1"},
+			...
 		]
 	} ,
 	
@@ -51,7 +57,7 @@ System.out doesn't represent a file, but a stream to the shell. The last tool in
 }
 ```
 
-Each entry in the list contains the key "class", which stores the name of the class to be used. The remaining keys vary depending on this class.
+Each entry in the list contains the key "class", which stores the name of the class to be used. The remaining keys vary depending on the class.
 
 See [the template](src/template.conf.json) for more options.
 


### PR DESCRIPTION
Adds a few json configs to the examples. They each configure a pipeline equivalent to the shell script with the same name.
Adds a tutorial for the usage of json configs with explanations for some of the options.

Todo:
- [x] Finish the tutorial
- [ ] More pipelines?