### PR TITLE
Added TenTen conversion plus experiment example

### DIFF
--- a/examples/embedded-xml-example.sh
+++ b/examples/embedded-xml-example.sh
@@ -1,0 +1,29 @@
+# Experiment for testing XML bracketing extension.
+# Requires a part of the TenTen Corpus. We first extract all bracketing annotation from the
+# TenTen files and then convert it to CoNLL-RDF using the presented XMLTSV2RDF class.
+# Note that the TenTen Corpus allows for closing xml tags without opening. Using the
+# --repair argument we insert artificial opening nodes where needed.
+
+TENTEN=$1;
+CONLL="$TENTEN".conll
+TTL="$TENTEN".ttl
+
+if [[ $TENTEN == "" ]]; then
+  echo "Provide the path to the TenTen file, please."
+  else
+if [ ! -e "$TTL" ]; then
+  cat $TENTEN | \
+#    head -n 2500 | \
+    ./run.sh TenTen2XMLTSV -r | tee "$CONLL" | \
+    ./run.sh XMLTSV2RDF http://replace.me TOK LEM POS_COARSE POS MORPH HEAD_A HEAD_B LEM_ALT LEM_ALT2 > "$TTL"
+fi;
+
+## Count the number of XML nodes in the intermediate file.
+echo "Before conversion: $(awk -F'<' 'NF==2' "$CONLL" |\
+  grep -c "/>\|<[^/]")"
+
+## Count the number of XML:data in the resulting file
+echo "After conversion: $(arq --data="$TTL" \
+    --query=sparql/count_xml_triples.sparql \
+    --results=TSV | grep -v '^?')"
+fi;

--- a/examples/sparql/count_xml_triples.sparql
+++ b/examples/sparql/count_xml_triples.sparql
@@ -1,0 +1,5 @@
+PREFIX x: <http://purl.org/acoli/conll-rdf/xml#> 
+PREFIX conll: <http://ufal.mff.cuni.cz/conll2009-st/task-description.html#>
+SELECT COUNT(?x) WHERE {
+ ?x a conll:XML_DATA.
+}

--- a/src/org/acoli/conll/rdf/TenTen2XMLTSV.java
+++ b/src/org/acoli/conll/rdf/TenTen2XMLTSV.java
@@ -1,0 +1,297 @@
+package org.acoli.conll.rdf;
+
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+
+import java.io.*;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TenTen2XMLTSV {
+
+
+	List<String> tagsContainingData = Arrays.asList("kwik", "left", "right");
+	private static Logger LOG = Logger.getLogger(TenTen2XMLTSV.class.getName());
+	public boolean isKEEP() {
+		return KEEP;
+	}
+	public void setKEEP(boolean KEEP) {
+		this.KEEP = KEEP;
+	}
+	public void setREPAIR(boolean REPAIR) { this.REPAIR = REPAIR;}
+
+	private boolean KEEP = false;
+	private boolean REPAIR = false;
+
+	TenTen2XMLTSV() {
+	}
+	TenTen2XMLTSV(List<String> tags, boolean keep, boolean repair) {
+		if (tags.size() > 0)
+			this.tagsContainingData = tags;
+		this.KEEP = keep;
+		this.REPAIR = repair;
+		LOG.info("Tags: "+this.tagsContainingData);
+		LOG.info("Keep: "+this.KEEP);
+		LOG.info("Repair: "+this.REPAIR);
+	}
+	class Line {
+		boolean isOpening = false;
+		boolean isClosing = false;
+		boolean isSelfClosing = false;
+		boolean isCoNLL = false;
+		final String data;
+		Line (String str) {
+			if (str.trim().matches("<[^/]*>")) {
+				LOG.debug(str+" is opening bracket");
+				this.isOpening = true;
+			} else if (str.trim().matches("</(.*)>")) {
+				LOG.debug(str+" is closing bracket");
+				this.isClosing = true;
+			} else if (str.trim().matches("<(.*)/>")){
+				LOG.debug(str+" is self-closing bracket");
+				this.isSelfClosing = true;
+			} else {
+				LOG.debug(str+" is CoNLL");
+				this.isCoNLL = true;
+			}
+			if (isClosing || isOpening || isSelfClosing) {
+				this.data = str.trim();
+			} else {
+				this.data = str;
+			}
+		}
+
+		@Override
+		public String toString() {
+			return data;
+		}
+
+		public String getName() {
+			if (isSelfClosing || isOpening || isClosing) {
+				return data.trim().replaceAll("[<>/]","");
+			} else {
+				return null;
+			}
+		}
+		public boolean sameName(Line other) {
+			return this.getName().equals(other.getName());
+		}
+		public Line toOpening() {
+			if (!isCoNLL) {
+				return new Line(data.trim().replace("/",""));
+			} else {
+				return null;
+			}
+		}
+		@Override
+		public boolean equals(Object other){
+			if((other == null) || (getClass() != other.getClass())){
+				return false;
+			}
+			else{
+				Line otherLine = (Line) other;
+				return data.equals(otherLine.data);
+			}
+		}
+		@Override
+		public int hashCode() {
+			return getName().hashCode();
+		}
+	}
+
+	/**
+	 * Splits stuff like </s><s> into two separate lines.
+	 * @param line
+	 * @return
+	 */
+	List<Line> splitMultipleBracketsInSingleLine(String line) {
+		List<Line> result = new ArrayList<>();
+		for (String elem : line.split(">")) {
+			LOG.debug("Bracket in buffer element: "+elem+">");
+			result.add(new Line(elem+">".trim()));
+		}
+		return result;
+	}
+
+	List<Line> splitEmbeddedCoNLL(String conll) {
+		List<Line> result = new ArrayList<>();
+		StringBuilder buffer = new StringBuilder();
+		boolean insideBracket = false;
+		for (int i = 0; i < conll.length(); i++) {
+			Character charAt = conll.charAt(i);
+
+			if (insideBracket) {
+				if (charAt.toString().equals(">")){
+					insideBracket = false;
+				}
+				buffer.append(charAt);
+			} else {
+				if (charAt.toString().equals("<")){
+					insideBracket = true;
+				}
+
+				if (charAt.toString().equals(" ") && buffer.toString().trim().length() > 0) {
+					if (StringUtils.countMatches(buffer.toString(), "/") >= 8) { // TODO: parameterize
+						LOG.debug("Data conll line in buffer: "+buffer.toString());
+						result.add(new Line(buffer.toString().trim()));
+					} else {
+						// embeddings
+						if (StringUtils.countMatches(buffer.toString(), ">") > 1) {
+							// we have more than one embedding, we have to split them
+							result.addAll(splitMultipleBracketsInSingleLine(buffer.toString()));
+						} else {
+							LOG.debug("Bracket in buffer: "+buffer.toString());
+							result.add(new Line(buffer.toString().trim()));
+						}
+					}
+					buffer = new StringBuilder();
+				}
+				buffer.append(charAt);
+			}
+		}
+		if (StringUtils.countMatches(buffer.toString(), "/") < 8 && StringUtils.countMatches(buffer.toString(), ">") > 1) {
+			result.addAll(splitMultipleBracketsInSingleLine(buffer.toString()));
+		} else {
+			result.add(new Line(buffer.toString()));
+		}
+		return result;
+	}
+
+	String embeddedCoNLL2CoNLL(String embeddedCoNLL) {
+		if (embeddedCoNLL.contains("<") && embeddedCoNLL.contains(">")) {
+			// There is some bracketing going on..
+			if (StringUtils.countMatches(embeddedCoNLL, "/") > 1) {
+				// It's one of those weird heading lines
+				boolean insideBracket = false;
+				StringBuilder conll = new StringBuilder();
+				for (int i = 0; i < embeddedCoNLL.length(); i++) {
+					Character charAt = embeddedCoNLL.charAt(i);
+					if (insideBracket) {
+						if (charAt.toString().equals(">")) {
+							insideBracket = false;
+						}
+						conll.append(charAt);
+					} else {
+						if (charAt.toString().equals("<")) {
+							insideBracket = true;
+						}
+						if (charAt.toString().equals("/")) {
+							conll.append("\t");
+						} else {
+							conll.append(charAt);
+						}
+					}
+				}
+				return conll.toString();
+			} else {
+				// It's a single xml bracket, but we properly split them in single one line elements
+				return embeddedCoNLL.trim();
+			}
+		} else {
+			// Finally the simple and raw data row, we replace / and be done with it.
+			return  embeddedCoNLL.replace("/", "\t");
+		}
+	}
+
+	Matcher matchEmbeddedCoNLL(String line) {
+		for (String tag : this.tagsContainingData) {
+			Pattern p = Pattern.compile("<"+tag+">(.*)</"+tag+">");
+			Matcher m = p.matcher(line);
+			if (m.matches()) {
+				return m;
+			}
+		}
+		return null;
+	}
+
+	void tenten2ttl(Reader in, Writer out) throws IOException {
+
+		BufferedReader bin = new BufferedReader(in);
+		Pattern p = Pattern.compile("<left>(.*)</left>");
+		List<Line> brackets = new ArrayList<>();
+		LOG.info("Reading..");
+		for (String line = ""; line!=null; line=bin.readLine()) {
+			Matcher m = matchEmbeddedCoNLL(line.trim());
+			if (m != null && m.matches()) {
+				String content = m.group(1);
+				LOG.debug("Content is: "+content);
+				String withEscaped = replaceEscapes(content);
+				LOG.debug("Escaped is: "+withEscaped);
+				List<Line> split = splitEmbeddedCoNLL(withEscaped);
+				LOG.debug("Splitted into: "+split);
+				for (Line spltStr : split) {
+					if (!spltStr.isCoNLL) {
+						LOG.debug("Before: " + spltStr);
+					}
+					String result = embeddedCoNLL2CoNLL(spltStr.data);
+					if (!spltStr.isCoNLL && this.REPAIR) {
+						if (spltStr.isOpening) {
+							brackets.add(spltStr);
+						}
+						if (spltStr.isClosing) {
+							if (!brackets.contains(spltStr.toOpening())) {
+								out.write("<"+spltStr.getName()+">");
+								out.write("\n");
+								LOG.debug("Artificially opened for "+spltStr+", brackets: "+brackets);
+							} else {
+								brackets.remove(spltStr.toOpening());
+							}
+						}
+					}
+					out.write(result);
+					out.write("\n");
+
+				}
+
+			} else {
+				if (isKEEP()) {
+					out.write(line+"\n");
+				} else {
+					LOG.debug("Skipping "+line);
+				}
+			}
+		}
+		out.flush();
+		LOG.info("Done.");
+	}
+
+	private String replaceEscapes(String content) {
+		return content.replaceAll("&lt;","<")
+				.replaceAll("&gt;",">")
+				.replaceAll("&quot;","\"");
+	}
+
+	public static void main(String[] argv) throws Exception {
+
+		boolean keep = false;
+		boolean repair = false;
+		boolean silent = false;
+		List<String> dataTags = new ArrayList<>();
+
+		for (int i = 0; i<argv.length; i++) {
+			if (argv[i].equals("--keep") || argv[i].equals("-k"))
+				keep = true;
+			else if (argv[i].equals("--repair") || argv[i].equals("-r"))
+				repair = true;
+			else if (argv[i].equals("--silent") || argv[i].equals("-s"))
+				silent = true;
+			else
+				dataTags.add(argv[i]);
+		}
+		if (silent)
+			LOG.setLevel(Level.OFF);
+
+		LOG.info("synopsis: CoNLLStreamExtractor ELEMENT1[.. ELEMENTn] [--keep|-k] [--repair|-r] [--silent|-s]\n"+
+			"\tELEMENTi      Name of XML Node to extract embedded CoNLL from\n"+
+			"\t--keep        Will keep XML that surrounds embedded CoNLL\n"+
+			"\t--repair      Will insert artificial opening brackets in case a closing one is encountered without opening\n"+
+			"\t--silent      Will silence all logging (Also this synopsis!)\n");
+		TenTen2XMLTSV tt2xt = new TenTen2XMLTSV(dataTags, keep, repair);
+
+		InputStreamReader in = new InputStreamReader(System.in);
+		tt2xt.tenten2ttl(in, new OutputStreamWriter(System.out));
+	}
+}


### PR DESCRIPTION
Added a script that recreates experiment 3 in the tree extension paper for lrec 2020.
Transcribed the python script to convert TenTen -> XMLTSV to java.
requires arq to execute (Is packaged with Apache Jena so we should be able to expect that users will have it)
