### PR TITLE
CommonsCLI Command Line Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Download the repository from GitHub: `git clone https://github.com/acoli-repo/Co
 The source is compiled automatically once you run the tool via the `run.sh` bash script.
 
 ### Requirements
-* JDK (OpenJDK or Java SE) or , version 1.8 or higher.
+* JDK (OpenJDK or Java SE), version 1.8 or higher.
   * run `java -version` to check if java is installed.
   * run `javac -version` to check if your version of the compiler is sufficient.
 * Maven 3.3+ (Optional but highly recommended).
@@ -83,7 +83,7 @@ Synopsis: `CoNLLRDFUpdater -custom [-model URI [GRAPH]] [-updates [UPDATE]]`
 
 ### CoNLLRDFFormatter
 `CoNLLRDFFormatter` expects conll-rdf in `.ttl` and writes to different formats. Can also visualize your data.  
-Synopsis: ```CoNLLRDFFormatter [-rdf [COLS]] [-debug] [-grammar] [-semantics] [-conll COLS] [-sparqltsv SPARQL]```
+Synopsis: ```CoNLLRDFFormatter [-rdf [COLS]] [-debug] [-grammar] [-semantics] [-conll COLS] [-query SPARQL]```
 
 It can write:
 * canonical conll-rdf as `.ttl`.

--- a/doc/classes.md
+++ b/doc/classes.md
@@ -15,6 +15,12 @@ All relevant classes are in [src/](../src/org/acoli/conll/rdf). Sample scripts i
 
 IMPORTANT USAGE HINT: All given data is parsed sentence-wise (if applicable). Meaning that for CoNLL data as input a newline is considered as a sentence boundary marker (in regard to the CoNLL data model). The ID column (if present) must contain sentence internal IDs (if this is not the case this column must be renamed before conversion/parsing) - if no such column is provided sentence internal IDs will be generated. Please refer to the paper mentioned below under Reference.
 
+### Universal Flags
+All conll-rdf pipeline components accept the following flags:
+
+* `help` Display usage help and exit.
+* `silent` Do not show info messages. Only messages of level warn and above will be logged to console.
+
 ### CoNLLRDFManager
 `CoNLLRDFManager` processes a pipeline provided as JSON.
 Synopsis: `CoNLLRDFManager -c [JSON-config]`
@@ -71,16 +77,19 @@ otherwise identical to `graphsout`.
 
 ### CoNLLRDFFormatter
 `CoNLLRDFFormatter` expects conll-rdf in `.ttl` and writes to different formats. Can also visualize your data.  
-Synopsis: ```CoNLLRDFFormatter [-rdf [COLS]] [-debug] [-grammar] [-semantics] [-conll COLS] [-sparqltsv SPARQL]```
+Synopsis: ```CoNLLRDFFormatter [-rdf [COLS]] [-debug] [-grammar] [-semantics] [-conll COLS] [-query SPARQL]```
 
 * `rdf` (default): writes canonical conll-rdf as .ttl.
 * `conll [COLS]`: writes .conll of specified columns in order of arguments. 
   * If no cols are provided, we assume the original conll was [CoNLL-U Plus](https://universaldependencies.org/ext-format.html).
     We first search for a `rdfs:comment` property with a `global.columns` comment, then the raw conll-like comments.
   * Note that we will overwrite any `global.columns` comments with the new column names, so you may read them with the `CoNLLStreamExtractor` again right away.
-* `sparqltsv [SPARQL-SELECT-FILE]`: writes TSV to `stdout` based on a given sparql select query.
+* `query [SPARQL-SELECT-FILE]`: writes TSV to `stdout` based on a given sparql select query.
   * column sequence is based on selector sequence within the sparql query.
   * writes the column names as a comment line before every sentence.
+* _DEPRECATED_ `sparqltsv` was deprecated in favor of `query`.
+  * functionally identical to `query`.
+  * has some undocumented behavior that can't be tested easily and was left untouched.
 * `debug`: writes highlighted .ttl to `stderr`, e.g. highlighting triples representing conll columns or sentence structure differently. 
   * does not work in combination with `-conll`.
   * to add custom highlighting you can add rules to `colorTTL(String buffer)` in `CoNLLRDFFormatter.java`. Don't forget to recompile!

--- a/examples/README.md
+++ b/examples/README.md
@@ -236,7 +236,7 @@ cat en-ud-dev.conllu \
 [...]
 ```
 ```shell
-	| ../run.sh CoNLLRDFFormatter -sparqltsv sparql/analyze/eval-POSsynt.sparql
+	| ../run.sh CoNLLRDFFormatter -query sparql/analyze/eval-POSsynt.sparql
 ```
 ```Turtle
 # global.columns = word upos udep POSsynt_UPOS POSsynt_UDEP match
@@ -264,7 +264,7 @@ cat en-ud-dev.conllu \
         sparql/analyze/UPOS-to-POSsynt.sparql \
         sparql/analyze/EDGE-to-POSsynt.sparql \
         sparql/analyze/consolidate-POSsynt.sparql \
-    | ../run.sh CoNLLRDFFormatter -sparqltsv sparql/analyze/eval-POSsynt.sparql \
+    | ../run.sh CoNLLRDFFormatter -query sparql/analyze/eval-POSsynt.sparql \
     | grep -v '#';
 ```
 

--- a/examples/analyze-ud.sh
+++ b/examples/analyze-ud.sh
@@ -24,5 +24,5 @@ $ROOT/run.sh CoNLLStreamExtractor \
         sparql/analyze/UPOS-to-POSsynt.sparql \
         sparql/analyze/EDGE-to-POSsynt.sparql \
         sparql/analyze/consolidate-POSsynt.sparql \
-    | ../run.sh CoNLLRDFFormatter -sparqltsv sparql/analyze/eval-POSsynt.sparql \
+    | ../run.sh CoNLLRDFFormatter -query sparql/analyze/eval-POSsynt.sparql \
 	| grep -v '#';

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.25</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFAnnotator.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFAnnotator.java
@@ -16,12 +16,11 @@
 package org.acoli.conll.rdf;
 
 import java.io.*;
-import java.net.*;
 import java.util.*;
-import org.apache.jena.rdf.model.*;		// Jena 2.x
-import org.apache.jena.update.*;
 import org.apache.log4j.Logger;
-import org.apache.jena.query.*;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.ParseException;
 
 
 /** a simple, shell-based annotator for CoNLL-RDF, requires Un*x shells with color highlighting<br/>
@@ -32,30 +31,39 @@ import org.apache.jena.query.*;
  *  @author Christian Chiarcos {@literal chiarcos@informatik.uni-frankfurt.de}
  */
 public class CoNLLRDFAnnotator extends CoNLLRDFFormatter {
+	private static Logger LOG = Logger.getLogger(CoNLLRDFAnnotator.class);
 	
-		private static Logger LOG = Logger.getLogger(CoNLLRDFAnnotator.class.getName());
+	public static void main(String[] args) throws IOException {
+		BufferedReader in;
+		BufferedReader commands = new BufferedReader(new InputStreamReader(System.in));
+		try {
+			final CommandLine cmd = new CoNLLRDFCommandLine("CoNLLRDFAnnotator file.ttl",
+					"Manual, sentence-wise annotation of a canonically formatted CoNLL TTL File. Visualization like CoNLLRDFFormatter -grammar. Writes CoNLL-RDF to stdout (make sure to write this to a file, your annotation is only contained here)",
+					new Option[] {}, LOG).parseArgs(args);
 
-		public static void main(String[] argv) throws IOException {
-			LOG.info("synopsis: CoNLLRDFAnnotator file.ttl \n"
-					+ "read canonically formatted CoNLL TTL sentence-wise\n"
-					+ "visualize like CoNLLRDFFormatter -grammar\n"
-					+ "manual, text-based annotation\n"
-					+ "write CoNLL-RDF to stdout (make sure to write this to a file, your annotation is only contained here)");
+			List<String> argList = cmd.getArgList();
+			if (argList.isEmpty()) {
+				throw new ParseException("Missing required argument file.ttl.");
+			}
+			in = new BufferedReader(new FileReader(argList.remove(0)));
+		} catch (ParseException e) {
+			LOG.error(e);
+			System.exit(1);
+			return;
+		}
 
-			BufferedReader in = new BufferedReader(new FileReader(argv[0]));
 			String line;
 			String lastLine ="";
 			String buffer="";
 
-			BufferedReader cmds = new BufferedReader(new InputStreamReader(System.in));
-			String cmd = "";
+		String command = "";
 			String macros = "^([0-9]+) ([0-9]+) (.+)$\t$1/HEAD=$2/EDGE=$3\n";
 			while((line = in.readLine())!=null) {
 				line=line.replaceAll("[\t ]+"," ").trim();
 
 				if(!buffer.trim().equals(""))
 					if((line.startsWith("@") || line.startsWith("#")) && !lastLine.startsWith("@") && !lastLine.startsWith("#")) {
-						while(!cmd.trim().equals(">")) {
+					while(!command.trim().equals(">")) {
 							System.err.print(
 							  "actions ............................................................................................................\n"+
 							  "        : "+ANSI_BLUE+"$nr/$att=$val"+ANSI_RESET+"   for element number $nr, set CoNLL property $att to $val, e.g., \"1/POS=NOUN\"              :\n"+
@@ -73,16 +81,16 @@ public class CoNLLRDFAnnotator extends CoNLLRDFFormatter {
 								System.err.println("macros    "+ANSI_RED+macros.replaceAll("\n",ANSI_RESET+"\n          "+ANSI_RED).replaceAll("\t","\t"+ANSI_RESET+"=>\t"+ANSI_BLUE)+ANSI_RESET);
 							System.err.print("| ----------------------------\n| "+CoNLLRDFFormatter.extractCoNLLGraph(buffer,true).replaceAll("\n","\n| ")+"-----------------------------\n"+
 								"command: ");
-							cmd=cmds.readLine().trim();
-							cmd=applyMacros(macros,cmd);
-							if(cmd.equals(">")) {
+						command=commands.readLine().trim();
+						command=applyMacros(macros,command);
+						if(command.equals(">")) {
 								System.out.println(buffer+"\n");
 								buffer="";
-							} else if(cmd.equals("m")) {
+						} else if(command.equals("m")) {
 								System.err.print("left hand side (what is entered):               ");
-								String lhs = cmds.readLine().replaceAll("\t"," ");
+							String lhs = commands.readLine().replaceAll("\t"," ");
 								System.err.print("right hand side (or <ENTER> to delete macro):   ");
-								String rhs=cmds.readLine().replaceAll("\t"," ");
+							String rhs=commands.readLine().replaceAll("\t"," ");
 								if(rhs.equals("")) {
 									String tmp = "";
 									for(String macro : macros.split("\n"))
@@ -93,10 +101,10 @@ public class CoNLLRDFAnnotator extends CoNLLRDFFormatter {
 									macros=macros+lhs+"\t"+rhs+"\n";
 								}
 							} else {
-								buffer=updateBuffer(buffer,cmd);
+							buffer=updateBuffer(buffer,command);
 							}
 						}
-						cmd = "";
+					command = "";
 					}
 				//System.err.println(ANSI_RED+"> "+line+ANSI_RESET);
 				if(line.trim().startsWith("@") && !lastLine.trim().endsWith("."))
@@ -118,7 +126,7 @@ public class CoNLLRDFAnnotator extends CoNLLRDFFormatter {
 				//System.out.println();
 				lastLine=line;
 			}
-			cmds.close();
+		commands.close();
 			in.close();
 			LOG.info("done");
 	}

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFCommandLine.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFCommandLine.java
@@ -1,0 +1,323 @@
+package org.acoli.conll.rdf;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.UUID;
+import java.util.zip.GZIPInputStream;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryException;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.update.UpdateFactory;
+import org.apache.jena.update.UpdateRequest;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+
+class CoNLLRDFCommandLine {
+	private static final Logger LOG = Logger.getLogger(CoNLLRDFCommandLine.class);
+	private final Logger logger;
+	private final String syntax;
+	private final String header;
+	private final String footer;
+	private final Options options;
+	private final HelpFormatter helpFormatter = new HelpFormatter();
+
+	/**
+	 * Command Line Handler, parses args[] and prints usage help
+	 *
+	 * @param syntax      e.g. CoNLLStreamExtractor baseURI [ FIELD ... ]
+	 * @param description e.g. reads CoNLL from stdin, splits sentences, creates CoNLL RDF, applies SPARQL queries
+	 * @param options     the command line options
+	 * @param logger      the calling class' Log4j Logger
+	 */
+	CoNLLRDFCommandLine(String syntax, String description, Iterator<Option> options, Logger logger) {
+		this.logger = logger;
+		this.syntax = syntax;
+		this.header = description;
+		this.footer = null;
+		this.options = new Options()
+			.addOption("help", false, "print this help message and exit")
+			.addOption("silent", false, "supress help message and logging of info messages");
+
+		while (options.hasNext()) {
+			this.options.addOption(options.next());
+		}
+
+		helpFormatter.setOptionComparator(null); // don't sort cli-options in help message
+		helpFormatter.setSyntaxPrefix("synopsis: ");
+	}
+	CoNLLRDFCommandLine(String syntax, String description, Options options, Logger logger) {
+		this(syntax, description, options.getOptions().iterator(), logger);
+	}
+	CoNLLRDFCommandLine(String syntax, String description, Option[] options, Logger logger) {
+		this(syntax, description, Arrays.asList(options).iterator(), logger);
+	}
+
+	/**
+	 *
+	 * @param args
+	 * @return the parsed Arguments as CommandLine
+	 * @throws ParseException
+	 */
+	public CommandLine parseArgs(String[] args) throws ParseException {
+		final CommandLine cmd;
+		try {
+			cmd = new DefaultParser().parse(this.options, args);
+		} catch (ParseException e) {
+			logUsageHelp();
+			throw e;
+		}
+
+		LOG.debug("String[] args = " + Arrays.toString(args));
+		LOG.debug("Option[] opts = " + Arrays.deepToString(cmd.getOptions()));
+		LOG.debug("Unparsed args = " + cmd.getArgList().toString());
+
+		// print help and exit
+		if (cmd.hasOption("help")) {
+			printUsageHelp();
+			System.exit(0);
+		}
+		if (cmd.hasOption("silent")) {
+			logger.setLevel(Level.WARN);
+		}
+
+		// READ LOGLEVEL
+		if (cmd.hasOption("loglevel")) {
+			logger.setLevel(Level.toLevel(cmd.getOptionValue("loglevel")));
+		}
+		return cmd;
+	}
+
+	/**
+	 * Print usage help to stderr
+	 */
+	private void printUsageHelp() {
+		helpFormatter.printHelp(syntax, header, options, footer);
+	}
+	/**
+	 * Log usage help with LOG.info
+	 */
+	private void logUsageHelp() {
+		final StringWriter info = new StringWriter();
+		final PrintWriter pw = new PrintWriter(info);
+
+		helpFormatter.printHelp(pw, 80, syntax, header, options, helpFormatter.getLeftPadding(),
+				helpFormatter.getDescPadding(), footer);
+		pw.flush();
+
+		// add new line after logger's own prefix
+		logger.info("\n" + info.toString());
+	}
+
+	/**
+	 * Read an entire file to String, encoded as UTF-8. Intended to load small files
+	 * like sparql queries into memory. Implementation of
+	 * {@Code Files.readString(Path path)} available in Java 11
+	 *
+	 * @param path the path to the file
+	 * @return a String containing the content read from the file
+	 * @throws IOException              if the read fails
+	 * @throws IllegalArgumentException if the file is reported as larger than 2GB
+	 */
+	public static String readString(Path path) throws IOException {
+		// Files.readString(path, StandardCharsets.UTF_8); // requires Java 11
+		if (path.toFile().length() > 2000000000) {
+			throw new IllegalArgumentException(
+					"The file " + path + " is too large. " + path.toFile().length() + " bytes");
+		}
+		byte[] buffer = new byte[(int) path.toFile().length()];
+		buffer = Files.readAllBytes(path);
+		return new String(buffer, StandardCharsets.UTF_8);
+	}
+
+	public static String readUrl(URL url) throws IOException {
+		BufferedReader reader;
+		if (url.toString().endsWith(".gz")) {
+			reader = new BufferedReader(new InputStreamReader(new GZIPInputStream(url.openStream()), StandardCharsets.UTF_8));
+		} else {
+			reader = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8));
+		}
+		StringBuilder out = new StringBuilder();
+		for (String line = reader.readLine(); line != null; line = reader.readLine())
+			out.append(line + "\n");
+		return out.toString();
+	}
+
+	public static Query selectQueryFromLiteral(String arg) {
+		final Query query = QueryFactory.create(arg);
+		if (query.isSelectType()) {
+			return query;
+		} else {
+			throw new IllegalArgumentException("The provided query is not a select query: " + arg);
+		}
+	}
+	public static UpdateRequest updateRequestFromLiteral(String arg) {
+		return UpdateFactory.create(arg);
+	}
+
+	public static String readSparqlFile(String arg) throws IOException {
+		Path path = Paths.get(arg);
+		File file = path.toFile();
+
+		if (file.isFile() && file.exists()) { // can be read from a file
+			LOG.debug("Found File " + arg + " with length " + file.length());
+		}
+		if ( ! arg.endsWith(".sparql")) {
+			throw new IllegalArgumentException("File " + arg + " has an unexpected extension. expected '.sparql'");
+		}
+		return readString(path);
+	}
+
+	public static Query readSparqlSelect(String arg) throws IOException {
+		// arg = arg.strip();
+		try {
+			if (new File(arg).exists()) {
+				return selectQueryFromLiteral(readString(Paths.get(arg)));
+			}
+		} catch (InvalidPathException e) {
+			LOG.debug(e);
+		}
+		try {
+			return selectQueryFromLiteral(readUri(new URI(arg)));
+		} catch (URISyntaxException e) {
+			LOG.debug(e);
+		}
+		// read as literal
+		try {
+			return selectQueryFromLiteral(arg);
+		} catch (QueryException e) {
+			LOG.debug(e);
+		}
+		throw new IllegalArgumentException("arg could not be read as sparql");
+	}
+	public static Model readModel(URI uri) throws IOException {
+		Model m = ModelFactory.createDefaultModel();
+		return m.read(readUri(uri));
+	}
+
+	/**
+	 * Tries to read from a specific URI.
+	 * Tries to read content directly or from GZIP
+	 * Validates content against UTF-8.
+	 * @param uri
+	 * 		the URI to be read
+	 * @return
+	 * 		the text content
+	 * @throws MalformedURLException
+	 * @throws IOException
+	 */
+	public static String readUri(URI uri) throws MalformedURLException, IOException {
+		if (uri.isAbsolute()){
+			return readUrl(uri.toURL());
+		} else {
+			return readString(Paths.get(uri));
+		}
+	}
+
+	public static Writer newFileWriter(File outputDir, String updateName, String sentence_id, int update_id, int iteration, int step, String fileExtension) throws FileNotFoundException {
+		if (updateName != null && !updateName.isEmpty()) {
+			updateName = updateName.replace(".sparql", "");
+		} else {
+			updateName = UUID.randomUUID().toString();
+		}
+		File file = new File(outputDir,
+			String.format(
+				"%s__U%03d_I%04d_S%03d__%s%s",
+				sentence_id, update_id, iteration, step, updateName, fileExtension)
+			);
+		return new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
+	}
+
+	public static Pair<String, String> parseUpdate(String arg) throws IOException, ParseException {
+		final String updateRaw = arg.replaceFirst("\\{[0-9u*]+\\}$", "");
+		String freq = arg.replaceFirst(".*\\{([0-9u*]+)\\}$", "$1");
+		if (arg.equals(freq)) {
+			freq = "1";
+		} else if (freq.equals("u")) {
+			freq = "*";
+	}
+		return new ImmutablePair<>(updateRaw, freq);
+	}
+
+	public static File parseDir(String arg) throws IOException {
+		// arg = arg.toLowerCase(); // FIXME why?
+		File dir = new File(arg);
+		if (dir.exists() || dir.mkdirs()) {
+			if (! dir.isDirectory()) {
+				dir = null;
+				throw new IOException("Error: Given directory is not valid: " + arg);
+			}
+		} else {
+			dir = null;
+			throw new IOException("Error: Failed to create given directory: " + arg);
+		}
+		return dir;
+	}
+
+	/**
+	 * Legacy parsing of Sparql (Select) Queries that may be provided verbatim
+	 * @return a String containing the Query
+	 * @throws IOException if the argument isn't a query, or valid file, or url
+	 */
+	public static String parseSelectOptionLegacy(String sparqlArg) throws IOException {
+		// TODO Unit testing for this static Method
+		// TODO Reduce Code Duplication with select Option between StreamExtractor and Formatter
+		// FIXME Refactor and use helper methods (readFile etc)
+		String sparql = "";
+
+		Reader sparqlreader = new StringReader(sparqlArg);
+		File file = new File(sparqlArg);
+		URL url = null;
+		try {
+			url = new URL(sparqlArg);
+		} catch (MalformedURLException e) {
+		}
+
+		if (file.exists()) { // can be read from a file
+			sparqlreader = new FileReader(file);
+		} else if (url != null) {
+			try {
+				sparqlreader = new InputStreamReader(url.openStream());
+			} catch (Exception e) {
+			}
+		}
+
+		BufferedReader in = new BufferedReader(sparqlreader);
+		for (String line = in.readLine(); line != null; line = in.readLine()) {
+			sparql = sparql + line + "\n";
+		}
+		return sparql;
+	}
+}

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFComponent.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFComponent.java
@@ -7,10 +7,9 @@ import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.cli.ParseException;
-
 public abstract class CoNLLRDFComponent implements Runnable {
 	static final List<Integer> CHECKINTERVAL = Arrays.asList(3, 10, 25, 50, 100, 200, 500);
+	static final String DEFAULTUPDATENAME = "DIRECTUPDATE";
 	// maximal update iterations allowed until the update loop is canceled and an error msg is thrown
 	// (to prevent faulty update scripts running in an endless loop)
 	static final int MAXITERATE = 999;
@@ -46,4 +45,7 @@ public abstract class CoNLLRDFComponent implements Runnable {
 	public final void start() {
 		run();
 	}
+
+	// TODO Address Code duplication of main methods
+	// TODO Unify Logging of process durations
 }

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFComponent.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFComponent.java
@@ -7,6 +7,8 @@ import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.cli.ParseException;
+
 public abstract class CoNLLRDFComponent implements Runnable {
 	static final List<Integer> CHECKINTERVAL = Arrays.asList(3, 10, 25, 50, 100, 200, 500);
 	// maximal update iterations allowed until the update loop is canceled and an error msg is thrown

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFComponent.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFComponent.java
@@ -1,34 +1,47 @@
 package org.acoli.conll.rdf;
 
 import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.List;
 
 public abstract class CoNLLRDFComponent implements Runnable {
+	static final List<Integer> CHECKINTERVAL = Arrays.asList(3, 10, 25, 50, 100, 200, 500);
+	// maximal update iterations allowed until the update loop is canceled and an error msg is thrown
+	// (to prevent faulty update scripts running in an endless loop)
+	static final int MAXITERATE = 999;
 
-	private BufferedReader inputStream;
-	private PrintStream outputStream;
-	
-	
+	private BufferedReader inputStream = new BufferedReader(new InputStreamReader(System.in));
+	private PrintStream outputStream = System.out;
 
+	protected abstract void processSentenceStream() throws IOException;
 
-	public BufferedReader getInputStream() {
+	public final BufferedReader getInputStream() {
 		return inputStream;
 	}
-
-	public void setInputStream(BufferedReader inputStream) {
+	public final void setInputStream(BufferedReader inputStream) {
 		this.inputStream = inputStream;
 	}
-
-	public PrintStream getOutputStream() {
+	public final PrintStream getOutputStream() {
 		return outputStream;
 	}
-
-	public void setOutputStream(PrintStream outputStream) {
+	public final void setOutputStream(PrintStream outputStream) {
 		this.outputStream = outputStream;
-	
 	}
 
-	public abstract void start();
-	
-	
+	@Override
+	public final void run() {
+		try {
+			processSentenceStream();
+		} catch (IOException e) {
+			e.printStackTrace();
+			System.exit(1);
+		}
+	}
+	// TODO is this method used anywhere?
+	public final void start() {
+		run();
+	}
 }

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFFormatter.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFFormatter.java
@@ -16,7 +16,6 @@
 package org.acoli.conll.rdf;
 
 import java.io.*;
-import java.net.*;
 import java.util.*;
 import org.apache.jena.rdf.model.*;		// Jena 2.x
 import org.apache.log4j.Logger;
@@ -94,13 +93,16 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 	}
 	
 	public static enum Mode {
-		CONLLRDF, CONLL, DEBUG, SPARQLTSV, GRAMMAR, SEMANTICS, GRAMMAR_SEMANTICS
+		CONLL, CONLLRDF, DEBUG, QUERY, GRAMMAR, SEMANTICS, GRAMMAR_SEMANTICS
 	}
 
 	private List<Module> modules = new ArrayList<Module>();
 	
 	public List<Module> getModules() {
 		return modules;
+	}
+	public boolean addModule(Module module) {
+		return modules.add(module);
 	}
 
 		/** do some highlighting, but provide the full TTL data*/
@@ -680,7 +682,7 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 							else
 								printSparql(buffer, columnsAsSelect(m.getCols()), new OutputStreamWriter(m.getOutputStream()));
 						}
-						if(m.getMode()==Mode.SPARQLTSV) printSparql(buffer, m.getSelect(), new OutputStreamWriter(m.getOutputStream()));
+						if(m.getMode()==Mode.QUERY) printSparql(buffer, m.getSelect(), new OutputStreamWriter(m.getOutputStream()));
 						if(m.getMode()==Mode.GRAMMAR) m.getOutputStream().println(extractCoNLLGraph(buffer,true));
 						if(m.getMode()==Mode.SEMANTICS) m.getOutputStream().println(extractTermGraph(buffer,true));
 						if(m.getMode()==Mode.GRAMMAR_SEMANTICS) {
@@ -734,7 +736,7 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 				else
 					printSparql(buffer, columnsAsSelect(m.getCols()), new OutputStreamWriter(m.getOutputStream()));
 			}
-			if(m.getMode()==Mode.SPARQLTSV) printSparql(buffer, m.getSelect(), new OutputStreamWriter(m.getOutputStream()));
+			if(m.getMode()==Mode.QUERY) printSparql(buffer, m.getSelect(), new OutputStreamWriter(m.getOutputStream()));
 			if(m.getMode()==Mode.GRAMMAR) m.getOutputStream().println(extractCoNLLGraph(buffer,true));
 			if(m.getMode()==Mode.SEMANTICS) m.getOutputStream().println(extractTermGraph(buffer,true));
 			if(m.getMode()==Mode.GRAMMAR_SEMANTICS) {
@@ -744,123 +746,14 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 		}
 	}
 
-	public void configureFromCommandLine(String[] argv) throws IOException, ParseException {
-		LOG.info(
-			"synopsis: CoNLLRDFFormatter [-rdf [COLS]] [-debug] [-grammar] [-semantics] [-conll COLS] [-sparqltsv SPARQL]\n"
-					+ "\t-rdf  write formatted CoNLL-RDF to stdout (sorted by list of CoNLL COLS, if provided)\n"
-					+ "\t-conll  write formatted CoNLL to stdout (only specified COLS)\n"
-					+ "\t-debug     write formatted, color-highlighted full turtle to stderr\n"
-					+ "\t-grammar   write CoNLL data structures to stdout\n"
-					+ "\t-semantics write semantic graph to stdout\n"
-					+ "\t-sparqltsv write TSV generated from SPARQL statement to stdout.\n"
-					+ "\t           if with -grammar, then skip type assignments\n"
-					+ "read TTL from stdin => format CoNLL-RDF or extract and highlight CoNLL (namespace conll:) and semantic (namespace terms:) subgraphs\n"
-					+ "if no parameters are supplied, -conllrdf is inferred");
-		final String args = Arrays.asList(argv).toString().replaceAll("[\\[\\], ]+", " ").trim().toLowerCase();
-
-		boolean CONLLRDF = args.contains("-rdf");
-		final boolean CONLL = args.contains("-conll");
-		final boolean DEBUG = args.contains("-debug");
-		final boolean SPARQLTSV = args.contains("-sparqltsv");
-		final boolean GRAMMAR = args.contains("-grammar");
-		final boolean SEMANTICS = args.contains("-semantics");
-
-		Module module;
-
-		if (!CONLLRDF && !CONLL && !SPARQLTSV && !GRAMMAR && !SEMANTICS && !DEBUG) { // default
-			CONLLRDF = true;
-		}
-
-		if (GRAMMAR) {
-			module = new Module();
-			module.setMode(Mode.GRAMMAR);
-			module.setOutputStream(getOutputStream());
-			getModules().add(module);
-		}
-		if (SEMANTICS) {
-			module = new Module();
-			module.setMode(Mode.SEMANTICS);
-			module.setOutputStream(getOutputStream());
-			getModules().add(module);
-		}
-		if (DEBUG) {
-			module = new Module();
-			module.setMode(Mode.DEBUG);
-			module.setOutputStream(System.err);
-			getModules().add(module);
-		}
-		if (CONLL) {
-			module = new Module();
-			module.setMode(Mode.CONLL);
-			module.setOutputStream(getOutputStream());
-			module.getCols().clear();
-			int i = 0;
-			while (i < argv.length && argv[i].toLowerCase().matches("^-+conll$"))
-				i++;
-			while (i < argv.length && !argv[i].toLowerCase().matches("^-+.*$"))
-				module.getCols().add(argv[i++]);
-			getModules().add(module);
-		}
-		if (CONLLRDF) {
-			module = new Module();
-			module.setMode(Mode.CONLLRDF);
-			module.setOutputStream(getOutputStream());
-			module.getCols().clear();
-			int i = 0;
-			while (i < argv.length && argv[i].toLowerCase().matches("^-+rdf$"))
-				i++;
-			while (i < argv.length && !argv[i].toLowerCase().matches("^-+.*$"))
-				module.getCols().add(argv[i++]);
-			getModules().add(module);
-		}
-		if (SPARQLTSV) {
-			module = new Module();
-			module.setMode(Mode.SPARQLTSV);
-			module.setOutputStream(getOutputStream());
-			String select = "";
-			int i = 1;
-			while (i < argv.length && argv[i].toLowerCase().matches("^-+sparqltsv$"))
-				i++;
-			if (i < argv.length)
-				select = argv[i++];
-			while (i < argv.length)
-				select = select + " " + argv[i++]; // because queries may be parsed by the shell (Cygwin)
-
-			Reader sparqlreader = new StringReader(select);
-			File file = new File(select);
-			URL u = null;
-			try {
-				u = new URL(select);
-			} catch (MalformedURLException e) {
-			}
-
-			if (file.exists()) { // can be read from a file
-				sparqlreader = new FileReader(file);
-				LOG.debug("f");
-			} else if (u != null) {
-				try {
-					sparqlreader = new InputStreamReader(u.openStream());
-					LOG.debug("u");
-				} catch (Exception e) {
-				}
-			}
-
-			BufferedReader in = new BufferedReader(sparqlreader);
-			select = "";
-			for (String line = in.readLine(); line != null; line = in.readLine())
-				select = select + line + "\n";
-			module.setSelect(select);
-			getModules().add(module);
-		}
-	}
-
 	public static void main(String[] args) throws IOException {
-		final CoNLLRDFFormatter formatter = new CoNLLRDFFormatter();
+		final CoNLLRDFFormatter formatter;
 		try {
-			formatter.configureFromCommandLine(args);
+			formatter = new CoNLLRDFFormatterFactory().buildFromCLI(args);
 		} catch (ParseException e) {
 			LOG.error(e);
 			System.exit(1);
+			return;
 		}
 		formatter.processSentenceStream();
 	}

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFFormatter.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFFormatter.java
@@ -20,6 +20,7 @@ import java.net.*;
 import java.util.*;
 import org.apache.jena.rdf.model.*;		// Jena 2.x
 import org.apache.log4j.Logger;
+import org.apache.commons.cli.ParseException;
 import org.apache.jena.query.*;
 
 
@@ -62,24 +63,31 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 		public Mode getMode() {
 			return mode;
 		}
+
 		public void setMode(Mode mode) {
 			this.mode = mode;
 		}
+
 		public List<String> getCols() {
 			return cols;
 		}
+
 		public void setCols(List<String> cols) {
 			this.cols = cols;
 		}
+
 		public String getSelect() {
 			return select;
 		}
+
 		public void setSelect(String select) {
 			this.select = select;
 		}
+
 		public PrintStream getOutputStream() {
 			return outputStream;
 		}
+
 		public void setOutputStream(PrintStream outputStream) {
 			this.outputStream = outputStream;
 		}
@@ -607,119 +615,6 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 			out.flush();
 		}
 		
-		public static void main(String[] argv) throws IOException {
-			LOG.info("synopsis: CoNLLRDFFormatter [-rdf [COLS]] [-debug] [-grammar] [-semantics] [-conll COLS] [-sparqltsv SPARQL]\n"
-					+ "\t-rdf  write formatted CoNLL-RDF to stdout (sorted by list of CoNLL COLS, if provided)\n"
-					+ "\t-conll  write formatted CoNLL to stdout (only specified COLS)\n"
-					+ "\t-debug     write formatted, color-highlighted full turtle to stderr\n"
-					+ "\t-grammar   write CoNLL data structures to stdout\n"
-					+ "\t-semantics write semantic graph to stdout\n"
-					+ "\t-sparqltsv write TSV generated from SPARQL statement to stdout.\n"
-					+ "\t           if with -grammar, then skip type assignments\n"
-					+ "read TTL from stdin => format CoNLL-RDF or extract and highlight CoNLL (namespace conll:) and semantic (namespace terms:) subgraphs\n"
-					+ "if no parameters are supplied, -conllrdf is inferred");
-			String args = Arrays.asList(argv).toString().replaceAll("[\\[\\], ]+"," ").trim().toLowerCase();
-			
-			CoNLLRDFFormatter f = new CoNLLRDFFormatter();
-			boolean CONLLRDF = args.contains("-rdf");
-			boolean CONLL = args.contains("-conll");
-			boolean DEBUG = args.contains("-debug");
-			boolean SPARQLTSV = args.contains("-sparqltsv");
-			boolean GRAMMAR = args.contains("-grammar");
-			boolean SEMANTICS = args.contains("-semantics");
-			// if(!GRAMMAR && !SEMANTICS) { // default
-				// GRAMMAR=true;
-				// SEMANTICS=true;
-			// }
-			if(!CONLLRDF && !CONLL && !SPARQLTSV && !GRAMMAR && !SEMANTICS && !DEBUG) { // default
-				CONLLRDF = true;
-			}
-			
-			if(GRAMMAR) {
-				Module m = new Module();
-				m.setMode(Mode.GRAMMAR);
-				m.setOutputStream(f.getOutputStream());
-				f.getModules().add(m);
-			}
-			
-			if(SEMANTICS) {
-				Module m = new Module();
-				m.setMode(Mode.SEMANTICS);
-				m.setOutputStream(f.getOutputStream());
-				f.getModules().add(m);
-			}
-			
-			if(DEBUG) {
-				Module m = new Module();
-				m.setMode(Mode.DEBUG);
-				m.setOutputStream(System.err);
-				f.getModules().add(m);
-			}
-			
-			if(CONLL) {
-				Module m = new Module();
-				m.setMode(Mode.CONLL);
-				m.setOutputStream(f.getOutputStream());
-				m.getCols().clear();
-				int i = 0;
-				while(i<argv.length && argv[i].toLowerCase().matches("^-+conll$")) i++;
-				while(i<argv.length && !argv[i].toLowerCase().matches("^-+.*$"))
-					m.getCols().add(argv[i++]);
-				f.getModules().add(m);
-			}
-			
-			if(CONLLRDF) {
-				Module m = new Module();
-				m.setMode(Mode.CONLLRDF);
-				m.setOutputStream(f.getOutputStream());
-				m.getCols().clear();
-				int i = 0;
-				while(i<argv.length && argv[i].toLowerCase().matches("^-+rdf$")) i++;
-				while(i<argv.length && !argv[i].toLowerCase().matches("^-+.*$"))
-					m.getCols().add(argv[i++]);
-				f.getModules().add(m);
-			}
-			
-			if(SPARQLTSV) {
-				Module m = new Module();
-				m.setMode(Mode.SPARQLTSV);
-				m.setOutputStream(f.getOutputStream());
-				String select = "";
-				int i = 1;
-				while(i<argv.length && argv[i].toLowerCase().matches("^-+sparqltsv$")) i++;
-				if(i<argv.length)
-					select=argv[i++];
-				while(i<argv.length)
-					select=select+" "+argv[i++]; // because queries may be parsed by the shell (Cygwin)
-				
-				Reader sparqlreader = new StringReader(select);
-				File file = new File(select);
-				URL u = null;
-				try {
-					u = new URL(select);
-				} catch (MalformedURLException e) {}
-				
-				if(file.exists()) {			// can be read from a file
-					sparqlreader = new FileReader(file);
-					LOG.debug("f");
-				} else if(u!=null) {
-					try {
-						sparqlreader = new InputStreamReader(u.openStream());
-						LOG.debug("u");
-					} catch (Exception e) {}
-				}
-
-				BufferedReader in = new BufferedReader(sparqlreader);
-				select="";
-				for(String line = in.readLine(); line!=null; line=in.readLine())
-					select=select+line+"\n";
-				m.setSelect(select);
-				f.getModules().add(m);
-			}
-			
-			f.processSentenceStream();
-			
-		}
 
 	/**
 	 * Searches a string buffer that is expected to represent a sentence for any
@@ -847,5 +742,126 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 				m.getOutputStream().println(extractTermGraph(buffer,false));
 			}
 		}
+	}
+
+	public void configureFromCommandLine(String[] argv) throws IOException, ParseException {
+		LOG.info(
+			"synopsis: CoNLLRDFFormatter [-rdf [COLS]] [-debug] [-grammar] [-semantics] [-conll COLS] [-sparqltsv SPARQL]\n"
+					+ "\t-rdf  write formatted CoNLL-RDF to stdout (sorted by list of CoNLL COLS, if provided)\n"
+					+ "\t-conll  write formatted CoNLL to stdout (only specified COLS)\n"
+					+ "\t-debug     write formatted, color-highlighted full turtle to stderr\n"
+					+ "\t-grammar   write CoNLL data structures to stdout\n"
+					+ "\t-semantics write semantic graph to stdout\n"
+					+ "\t-sparqltsv write TSV generated from SPARQL statement to stdout.\n"
+					+ "\t           if with -grammar, then skip type assignments\n"
+					+ "read TTL from stdin => format CoNLL-RDF or extract and highlight CoNLL (namespace conll:) and semantic (namespace terms:) subgraphs\n"
+					+ "if no parameters are supplied, -conllrdf is inferred");
+		final String args = Arrays.asList(argv).toString().replaceAll("[\\[\\], ]+", " ").trim().toLowerCase();
+
+		boolean CONLLRDF = args.contains("-rdf");
+		final boolean CONLL = args.contains("-conll");
+		final boolean DEBUG = args.contains("-debug");
+		final boolean SPARQLTSV = args.contains("-sparqltsv");
+		final boolean GRAMMAR = args.contains("-grammar");
+		final boolean SEMANTICS = args.contains("-semantics");
+
+		Module module;
+
+		if (!CONLLRDF && !CONLL && !SPARQLTSV && !GRAMMAR && !SEMANTICS && !DEBUG) { // default
+			CONLLRDF = true;
+		}
+
+		if (GRAMMAR) {
+			module = new Module();
+			module.setMode(Mode.GRAMMAR);
+			module.setOutputStream(getOutputStream());
+			getModules().add(module);
+		}
+		if (SEMANTICS) {
+			module = new Module();
+			module.setMode(Mode.SEMANTICS);
+			module.setOutputStream(getOutputStream());
+			getModules().add(module);
+		}
+		if (DEBUG) {
+			module = new Module();
+			module.setMode(Mode.DEBUG);
+			module.setOutputStream(System.err);
+			getModules().add(module);
+		}
+		if (CONLL) {
+			module = new Module();
+			module.setMode(Mode.CONLL);
+			module.setOutputStream(getOutputStream());
+			module.getCols().clear();
+			int i = 0;
+			while (i < argv.length && argv[i].toLowerCase().matches("^-+conll$"))
+				i++;
+			while (i < argv.length && !argv[i].toLowerCase().matches("^-+.*$"))
+				module.getCols().add(argv[i++]);
+			getModules().add(module);
+		}
+		if (CONLLRDF) {
+			module = new Module();
+			module.setMode(Mode.CONLLRDF);
+			module.setOutputStream(getOutputStream());
+			module.getCols().clear();
+			int i = 0;
+			while (i < argv.length && argv[i].toLowerCase().matches("^-+rdf$"))
+				i++;
+			while (i < argv.length && !argv[i].toLowerCase().matches("^-+.*$"))
+				module.getCols().add(argv[i++]);
+			getModules().add(module);
+		}
+		if (SPARQLTSV) {
+			module = new Module();
+			module.setMode(Mode.SPARQLTSV);
+			module.setOutputStream(getOutputStream());
+			String select = "";
+			int i = 1;
+			while (i < argv.length && argv[i].toLowerCase().matches("^-+sparqltsv$"))
+				i++;
+			if (i < argv.length)
+				select = argv[i++];
+			while (i < argv.length)
+				select = select + " " + argv[i++]; // because queries may be parsed by the shell (Cygwin)
+
+			Reader sparqlreader = new StringReader(select);
+			File file = new File(select);
+			URL u = null;
+			try {
+				u = new URL(select);
+			} catch (MalformedURLException e) {
+			}
+
+			if (file.exists()) { // can be read from a file
+				sparqlreader = new FileReader(file);
+				LOG.debug("f");
+			} else if (u != null) {
+				try {
+					sparqlreader = new InputStreamReader(u.openStream());
+					LOG.debug("u");
+				} catch (Exception e) {
+				}
+			}
+
+			BufferedReader in = new BufferedReader(sparqlreader);
+			select = "";
+			for (String line = in.readLine(); line != null; line = in.readLine())
+				select = select + line + "\n";
+			module.setSelect(select);
+			getModules().add(module);
+		}
+	}
+
+	public static void main(String[] args) throws IOException {
+		final CoNLLRDFFormatter formatter = new CoNLLRDFFormatter();
+		try {
+			formatter.configureFromCommandLine(args);
+		} catch (ParseException e) {
+			LOG.error(e);
+			System.exit(1);
+		}
+		formatter.processSentenceStream();
 	}
 }

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFFormatter.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFFormatter.java
@@ -756,7 +756,8 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 			return columnNames;
 		}
 
-		public void processSentenceStream() throws IOException {
+	@Override
+		protected void processSentenceStream() throws IOException {
 			String line;
 			String lastLine ="";
 			String buffer="";
@@ -851,20 +852,5 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 					m.getOutputStream().println(extractTermGraph(buffer,false));
 				}
 			}
-		}
-
-		@Override
-		public void run() {
-			try {
-				processSentenceStream();
-			} catch (Exception e) {
-				e.printStackTrace();
-				System.exit(0);
-			}
-		}
-
-		@Override
-		public void start() {
-			run();
 		}
 }

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFFormatter.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFFormatter.java
@@ -757,49 +757,49 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 		}
 
 	@Override
-		protected void processSentenceStream() throws IOException {
-			String line;
-			String lastLine ="";
-			String buffer="";
-			while((line = getInputStream().readLine())!=null) {
-				line=line.replaceAll("[\t ]+"," ").trim();
+	protected void processSentenceStream() throws IOException {
+		String line;
+		String lastLine ="";
+		String buffer="";
+		while((line = getInputStream().readLine())!=null) {
+			line=line.replaceAll("[\t ]+"," ").trim();
 
-				if(!buffer.trim().equals(""))
-					if((line.startsWith("@") || line.startsWith("#")) && !lastLine.startsWith("@") && !lastLine.startsWith("#")) { //!buffer.matches("@[^\n]*\n?$")) {
-						for (Module m:modules) {
-							if(m.getMode()==Mode.CONLLRDF) m.getOutputStream().println(reorderTTLBuffer(buffer, m.getCols()));
-							if(m.getMode()==Mode.DEBUG) System.err.println(colorTTL(reorderTTLBuffer(buffer, m.getCols())));
-							if(m.getMode()==Mode.CONLL) {
-								if (m.getCols().size() < 1) {// no column args supplied
-									LOG.info("No column names in cmd args, searching rdf comments..");
-									List<String> conllColumns = findColumnNamesInRDFBuffer(buffer);
+			if(!buffer.trim().equals(""))
+				if((line.startsWith("@") || line.startsWith("#")) && !lastLine.startsWith("@") && !lastLine.startsWith("#")) { //!buffer.matches("@[^\n]*\n?$")) {
+					for (Module m:modules) {
+						if(m.getMode()==Mode.CONLLRDF) m.getOutputStream().println(reorderTTLBuffer(buffer, m.getCols()));
+						if(m.getMode()==Mode.DEBUG) System.err.println(colorTTL(reorderTTLBuffer(buffer, m.getCols())));
+						if(m.getMode()==Mode.CONLL) {
+							if (m.getCols().size() < 1) {// no column args supplied
+								LOG.info("No column names in cmd args, searching rdf comments..");
+								List<String> conllColumns = findColumnNamesInRDFBuffer(buffer);
+								if (conllColumns.size()>0) {
+									LOG.info("Using #global.comments from rdf");
+									m.setCols(conllColumns);
+								} else {
+									LOG.info("Trying conll columns now..");
+									conllColumns = CoNLLStreamExtractor.findFieldsFromComments(new BufferedReader(new StringReader(buffer.trim())), 1);
 									if (conllColumns.size()>0) {
-										LOG.info("Using #global.comments from rdf");
 										m.setCols(conllColumns);
-									} else {
-										LOG.info("Trying conll columns now..");
-										conllColumns = CoNLLStreamExtractor.findFieldsFromComments(new BufferedReader(new StringReader(buffer.trim())), 1);
-										if (conllColumns.size()>0) {
-											m.setCols(conllColumns);
-										}
 									}
 								}
-								if (m.getCols().size() < 1) {
-									LOG.info("Supply column names some way! (-conll arg, global.columns or rdf comments");
-								}
-								else
-									printSparql(buffer, columnsAsSelect(m.getCols()), new OutputStreamWriter(m.getOutputStream()));
 							}
-							if(m.getMode()==Mode.SPARQLTSV) printSparql(buffer, m.getSelect(), new OutputStreamWriter(m.getOutputStream()));
-							if(m.getMode()==Mode.GRAMMAR) m.getOutputStream().println(extractCoNLLGraph(buffer,true));
-							if(m.getMode()==Mode.SEMANTICS) m.getOutputStream().println(extractTermGraph(buffer,true));
-							if(m.getMode()==Mode.GRAMMAR_SEMANTICS) {
-								m.getOutputStream().println(extractCoNLLGraph(buffer,true));
-								m.getOutputStream().println(extractTermGraph(buffer,false));
+							if (m.getCols().size() < 1) {
+								LOG.info("Supply column names some way! (-conll arg, global.columns or rdf comments");
 							}
+							else
+								printSparql(buffer, columnsAsSelect(m.getCols()), new OutputStreamWriter(m.getOutputStream()));
 						}
-						buffer="";
+						if(m.getMode()==Mode.SPARQLTSV) printSparql(buffer, m.getSelect(), new OutputStreamWriter(m.getOutputStream()));
+						if(m.getMode()==Mode.GRAMMAR) m.getOutputStream().println(extractCoNLLGraph(buffer,true));
+						if(m.getMode()==Mode.SEMANTICS) m.getOutputStream().println(extractTermGraph(buffer,true));
+						if(m.getMode()==Mode.GRAMMAR_SEMANTICS) {
+							m.getOutputStream().println(extractCoNLLGraph(buffer,true));
+							m.getOutputStream().println(extractTermGraph(buffer,false));
+						}
 					}
+					buffer="";
+				}
 				//System.err.println(ANSI_RED+"> "+line+ANSI_RESET);
 				if(line.trim().startsWith("@") && !lastLine.trim().endsWith(".")) 
 					//System.out.print("\n");
@@ -821,36 +821,36 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 				lastLine=line;
 			}
 			
-			for (Module m:modules) {
-				if(m.getMode()==Mode.CONLLRDF) m.getOutputStream().println(reorderTTLBuffer(buffer, m.getCols()));
-				if(m.getMode()==Mode.DEBUG) System.err.println(colorTTL(reorderTTLBuffer(buffer, m.getCols())));
-				if(m.getMode()==Mode.CONLL) {
-					if (m.getCols().size() < 1) {
-						LOG.info("No column names in cmd args, searching rdf comments..");
-						List<String> conllColumns = findColumnNamesInRDFBuffer(buffer);
+		for (Module m:modules) {
+			if(m.getMode()==Mode.CONLLRDF) m.getOutputStream().println(reorderTTLBuffer(buffer, m.getCols()));
+			if(m.getMode()==Mode.DEBUG) System.err.println(colorTTL(reorderTTLBuffer(buffer, m.getCols())));
+			if(m.getMode()==Mode.CONLL) {
+				if (m.getCols().size() < 1) {
+					LOG.info("No column names in cmd args, searching rdf comments..");
+					List<String> conllColumns = findColumnNamesInRDFBuffer(buffer);
+					if (conllColumns.size()>0) {
+						LOG.info("Using #global.comments from rdf");
+						m.setCols(conllColumns);
+					} else {
+						LOG.info("Trying conll columns now..");
+						conllColumns = CoNLLStreamExtractor.findFieldsFromComments(new BufferedReader(new StringReader(buffer.trim())), 1);
 						if (conllColumns.size()>0) {
-							LOG.info("Using #global.comments from rdf");
 							m.setCols(conllColumns);
-						} else {
-							LOG.info("Trying conll columns now..");
-							conllColumns = CoNLLStreamExtractor.findFieldsFromComments(new BufferedReader(new StringReader(buffer.trim())), 1);
-							if (conllColumns.size()>0) {
-								m.setCols(conllColumns);
-							}
 						}
 					}
-					if (m.getCols().size() < 1)
-						throw new IOException("-conll argument needs at least one COL to export!");
-					else
-						printSparql(buffer, columnsAsSelect(m.getCols()), new OutputStreamWriter(m.getOutputStream()));
 				}
-				if(m.getMode()==Mode.SPARQLTSV) printSparql(buffer, m.getSelect(), new OutputStreamWriter(m.getOutputStream()));
-				if(m.getMode()==Mode.GRAMMAR) m.getOutputStream().println(extractCoNLLGraph(buffer,true));
-				if(m.getMode()==Mode.SEMANTICS) m.getOutputStream().println(extractTermGraph(buffer,true));
-				if(m.getMode()==Mode.GRAMMAR_SEMANTICS) {
-					m.getOutputStream().println(extractCoNLLGraph(buffer,true));
-					m.getOutputStream().println(extractTermGraph(buffer,false));
-				}
+				if (m.getCols().size() < 1)
+					throw new IOException("-conll argument needs at least one COL to export!");
+				else
+					printSparql(buffer, columnsAsSelect(m.getCols()), new OutputStreamWriter(m.getOutputStream()));
+			}
+			if(m.getMode()==Mode.SPARQLTSV) printSparql(buffer, m.getSelect(), new OutputStreamWriter(m.getOutputStream()));
+			if(m.getMode()==Mode.GRAMMAR) m.getOutputStream().println(extractCoNLLGraph(buffer,true));
+			if(m.getMode()==Mode.SEMANTICS) m.getOutputStream().println(extractTermGraph(buffer,true));
+			if(m.getMode()==Mode.GRAMMAR_SEMANTICS) {
+				m.getOutputStream().println(extractCoNLLGraph(buffer,true));
+				m.getOutputStream().println(extractTermGraph(buffer,false));
 			}
 		}
+	}
 }

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFFormatter.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFFormatter.java
@@ -621,11 +621,6 @@ public class CoNLLRDFFormatter extends CoNLLRDFComponent {
 			String args = Arrays.asList(argv).toString().replaceAll("[\\[\\], ]+"," ").trim().toLowerCase();
 			
 			CoNLLRDFFormatter f = new CoNLLRDFFormatter();
-			
-			f.setInputStream(new BufferedReader(new InputStreamReader(System.in)));
-			f.setOutputStream(System.out);
-			
-			
 			boolean CONLLRDF = args.contains("-rdf");
 			boolean CONLL = args.contains("-conll");
 			boolean DEBUG = args.contains("-debug");

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFFormatterFactory.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFFormatterFactory.java
@@ -23,7 +23,7 @@ public class CoNLLRDFFormatterFactory {
 	public CoNLLRDFFormatter buildFromCLI(String[] args) throws IOException, ParseException {
 		final CoNLLRDFFormatter formatter = new CoNLLRDFFormatter();
 		final CoNLLRDFCommandLine conllCli = new CoNLLRDFCommandLine(
-				"CoNLLRDFFormatter [-rdf [COLS]] [-conll COLS] [-debug] [-grammar] [-semantics] [-sparqltsv SPARQL]",
+				"CoNLLRDFFormatter [-rdf [COLS]] [-conll COLS] [-debug] [-grammar] [-semantics] [-query SPARQL]",
 				"read TTL from stdin => format CoNLL-RDF or extract and highlight CoNLL (namespace conll:) and semantic (namespace terms:) subgraphs\ndefaults to -rdf if no options are selected",
 				new Option[] {
 						// Define cli options in the correct order for the help-message
@@ -87,7 +87,7 @@ public class CoNLLRDFFormatterFactory {
 			formatter.addModule(module);
 		}
 		if (cmd.hasOption("query") && cmd.hasOption("sparqltsv")) {
-			throw new ParseException("Tried to use deprecated -sparqltsv and -query");
+			throw new ParseException("Tried to combine deprecated -sparqltsv and -query");
 		}
 
 		if (cmd.hasOption("grammar") && !cmd.hasOption("semantics")) {

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFFormatterFactory.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFFormatterFactory.java
@@ -1,0 +1,190 @@
+package org.acoli.conll.rdf;
+
+import static org.acoli.conll.rdf.CoNLLRDFCommandLine.readString;
+import static org.acoli.conll.rdf.CoNLLRDFCommandLine.readUrl;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import org.acoli.conll.rdf.CoNLLRDFFormatter.Mode;
+import org.acoli.conll.rdf.CoNLLRDFFormatter.Module;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.ParseException;
+import org.apache.log4j.Logger;
+
+public class CoNLLRDFFormatterFactory {
+	static Logger LOG = Logger.getLogger(CoNLLRDFFormatterFactory.class);
+
+	public CoNLLRDFFormatter buildFromCLI(String[] args) throws IOException, ParseException {
+		final CoNLLRDFFormatter formatter = new CoNLLRDFFormatter();
+		final CoNLLRDFCommandLine conllCli = new CoNLLRDFCommandLine(
+				"CoNLLRDFFormatter [-rdf [COLS]] [-conll COLS] [-debug] [-grammar] [-semantics] [-sparqltsv SPARQL]",
+				"read TTL from stdin => format CoNLL-RDF or extract and highlight CoNLL (namespace conll:) and semantic (namespace terms:) subgraphs\ndefaults to -rdf if no options are selected",
+				new Option[] {
+						// Define cli options in the correct order for the help-message
+						Option.builder("rdf").hasArgs().optionalArg(true)
+								.desc("write formatted CoNLL-RDF to stdout (sorted by list of CoNLL COLS, if provided)")
+								.build(),
+						Option.builder("conll").hasArgs().optionalArg(true)
+								.desc("write formatted CoNLL to stdout (only specified COLS)").build(),
+						new Option("debug", false, "write formatted, color-highlighted full turtle to stderr"),
+						new Option("grammar", false, "write CoNLL data structures to stdout"),
+						new Option("semantics", false,
+								"write semantic graph to stdout.\nif combined with -grammar, skip type assignments"),
+						new Option("query", true, "write TSV generated from SPARQL statement to stdout"),
+						new Option("sparqltsv", true, "deprecated: use -query instead") },
+				LOG);
+		// TODO which args are optional?
+		final CommandLine cmd = conllCli.parseArgs(args);
+
+		Module module;
+
+		if (cmd.hasOption("conll")) {
+			module = new Module();
+			module.setMode(Mode.CONLL);
+			module.setOutputStream(formatter.getOutputStream());
+			String[] optionValues = cmd.getOptionValues("conll");
+			if (optionValues != null) {
+				module.setCols(Arrays.asList(optionValues));
+			}
+			formatter.addModule(module);
+		}
+		if (cmd.hasOption("rdf")) {
+			module = new Module();
+			module.setMode(Mode.CONLLRDF);
+			module.setOutputStream(formatter.getOutputStream());
+			String[] optionValues = cmd.getOptionValues("rdf");
+			if (optionValues != null) {
+				module.setCols(Arrays.asList(optionValues));
+			}
+			formatter.addModule(module);
+		}
+		if (cmd.hasOption("debug")) {
+			module = new Module();
+			module.setMode(Mode.DEBUG);
+			module.setOutputStream(System.err);
+			formatter.addModule(module);
+		}
+
+		if (cmd.hasOption("sparqltsv")) {
+			LOG.warn("Option -sparqltsv has been deprecated in favor of -query");
+			module = new Module();
+			module.setMode(Mode.QUERY);
+			module.setOutputStream(formatter.getOutputStream());
+			module.setSelect(parseSparqlTSVOptionValues(cmd.getOptionValues("sparqltsv")));
+			formatter.addModule(module);
+		}
+		if (cmd.hasOption("query")) {
+			module = new Module();
+			module.setMode(Mode.QUERY);
+			module.setOutputStream(formatter.getOutputStream());
+			module.setSelect(parseSparqlTSVOptionValues(cmd.getOptionValues("query")));
+			formatter.addModule(module);
+		}
+		if (cmd.hasOption("query") && cmd.hasOption("sparqltsv")) {
+			throw new ParseException("Tried to use deprecated -sparqltsv and -query");
+		}
+
+		if (cmd.hasOption("grammar") && !cmd.hasOption("semantics")) {
+			module = new Module();
+			module.setMode(Mode.GRAMMAR);
+			module.setOutputStream(formatter.getOutputStream());
+			formatter.addModule(module);
+		}
+		if (cmd.hasOption("semantics") && !cmd.hasOption("grammar")) {
+			module = new Module();
+			module.setMode(Mode.SEMANTICS);
+			module.setOutputStream(formatter.getOutputStream());
+			formatter.addModule(module);
+		}
+		if (cmd.hasOption("semantics") && cmd.hasOption("grammar")) {
+			module = new Module();
+			module.setMode(Mode.GRAMMAR_SEMANTICS);
+			module.setOutputStream(formatter.getOutputStream());
+			formatter.addModule(module);
+		}
+
+		// if no modules were added, provide the default option
+		if (formatter.getModules().isEmpty()) {
+			LOG.info("No Option selected. Defaulting to Mode CoNLL-RDF");
+			module = new Module();
+			module.setMode(Mode.CONLLRDF);
+			module.setOutputStream(formatter.getOutputStream());
+			formatter.addModule(module);
+		}
+
+		return formatter;
+	}
+
+	static String parseSparqlTSVOptionValues(String[] optionValues) throws IOException, ParseException {
+		// FIXME Legacy Code
+		final String optionValue;
+
+		if (optionValues.length == 1) {
+			optionValue = optionValues[0];
+		} else if (optionValues.length == 0) {
+			// TODO this code should not be reachable
+			throw new ParseException("Option-Value for -sparqltsv is an empty string.");
+		} else {
+			// because queries may be parsed by the shell (Cygwin)
+			optionValue = String.join(" ", optionValues);
+		}
+
+		LOG.debug("Parsing Option-Value for -sparqltsv: " + optionValue);
+
+		if (new File(optionValue).exists()) {
+			LOG.debug("Attempting to read query from file");
+			return readString(Paths.get(optionValue));
+		}
+
+		try {
+			URL url = new URL(optionValue);
+			LOG.debug("Attempting to read query from URL");
+			return readUrl(url);
+		} catch (MalformedURLException e) {
+			LOG.debug(e);
+		}
+
+		// TODO consider verifying the output
+		LOG.debug("Returning unchanged Option Value as Query");
+		return optionValue;
+	}
+
+	static String parseQueryOptionValues(String[] optionValues) throws IOException, ParseException {
+		final String optionValue;
+		LOG.debug("Parsing Option-Value for -query");
+		// TODO only URL and File
+
+		if (optionValues.length == 1) {
+			optionValue = optionValues[0];
+		} else if (optionValues.length == 0) {
+			// TODO this code should not be reachable
+			optionValue = "";
+			return optionValue;
+		} else {
+			LOG.error("Parsing multiple queries in one operation is not supported at the moment.");
+			throw new ParseException("Expected a single file-path or URL as argument for query. Got "
+					+ optionValues.length + ":\n" + String.join(" ", optionValues));
+		}
+
+		if (new File(optionValue).exists()) {
+			LOG.debug("Attempting to read query from file");
+			return readString(Paths.get(optionValue));
+		}
+
+		try {
+			URL url = new URL(optionValue);
+			LOG.debug("Attempting to read query from URL");
+			return readUrl(url);
+		} catch (MalformedURLException e) {
+			LOG.debug(e);
+		}
+
+		throw new ParseException("Failed to parse Option-Value as file-path or URL: " + optionValue);
+	}
+}

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFManager.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFManager.java
@@ -23,12 +23,13 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.acoli.conll.rdf.CoNLLRDFFormatter.Mode;
 import org.acoli.conll.rdf.CoNLLRDFFormatter.Module;
-import org.acoli.conll.rdf.CoNLLRDFUpdater.Triple;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.commons.lang3.tuple.Triple;
 
 public class CoNLLRDFManager {
 	private ObjectNode config;
@@ -245,7 +246,7 @@ public class CoNLLRDFManager {
 					throw e;
 			}
 			String path = update.get("path").asText();
-			updates.add(new Triple<String, String, String>(path, path, freq));
+			updates.add(new ImmutableTriple<String, String, String>(path, path, freq));
 		}
 		updater.parseUpdates(updates);
 

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFManager.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFManager.java
@@ -23,45 +23,33 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.acoli.conll.rdf.CoNLLRDFFormatter.Mode;
 import org.acoli.conll.rdf.CoNLLRDFFormatter.Module;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
+import org.apache.log4j.Logger;
 
 public class CoNLLRDFManager {
+	static Logger LOG = Logger.getLogger(CoNLLRDFManager.class);
+
 	private ObjectNode config;
 	private ArrayList<CoNLLRDFComponent> componentStack;
 
 	PrintStream output;
 	BufferedReader input;
 
-	public static void main(String[] args) throws Exception {
-		Options options = new Options();
-		options.addRequiredOption("c", "config", true, "Specify JSON config file");
-
-		CommandLineParser parser = new DefaultParser();
-		CommandLine cmd = parser.parse(options, args);
-
-		CoNLLRDFManager man = new CoNLLRDFManager();
-
-		if(cmd.hasOption("c")) {
-			try {
-				man.readConfig(cmd.getOptionValue("c"));
-			} catch (IOException e) {
-				throw new Exception("Error when reading config file "+new File(cmd.getOptionValue("c")).getAbsolutePath(), e);
-			}
-		}
-		else {
-		    throw new ParseException("No config file specified.");
+	public static void main(String[] args) throws IOException {
+		final CoNLLRDFManager manager;
+		try {
+			manager = new CoNLLRDFManagerFactory().buildFromCLI(args);
+			manager.buildComponentStack();
+		} catch (ParseException e) {
+			LOG.error(e);
+			System.exit(1);
+			return;
 		}
 
-		man.buildComponentStack();
-		man.start();
+		manager.start();
 	}
-
 
 	public void readConfig(String path) throws IOException {
 		ObjectMapper objectMapper = new ObjectMapper();
@@ -110,7 +98,7 @@ public class CoNLLRDFManager {
 		return output;
 	}
 
-	public void buildComponentStack() throws IOException {
+	public void buildComponentStack() throws IOException, ParseException {
 		//READ INPUT PARAMETER
 		input = parseConfAsInputStream(config.get("input").asText());
 
@@ -179,7 +167,7 @@ public class CoNLLRDFManager {
 		return ex;
 	}
 
-	private CoNLLRDFComponent buildUpdater(ObjectNode conf) throws IOException {
+	private CoNLLRDFComponent buildUpdater(ObjectNode conf) throws IOException, ParseException {
 
 		// READ THREAD PARAMETERS
 		int threads = 0;
@@ -229,7 +217,7 @@ public class CoNLLRDFManager {
 		if (conf.get("prefixDeduplication") != null) {
 			Boolean prefixDeduplication = conf.get("prefixDeduplication").asBoolean();
 			if (prefixDeduplication)
-				updater.activateRemovePrefixDuplicates();
+				updater.activatePrefixDeduplication();
 		}
 
 		// READ ALL UPDATES
@@ -317,7 +305,7 @@ public class CoNLLRDFManager {
 				f.getModules().add(m);
 			}
 			if (modConf.get("mode").asText().equals("SPARQLTSV")) {
-				m.setMode(Mode.SPARQLTSV);
+				m.setMode(Mode.QUERY);
 				if (new File(modConf.get("select").asText()).canRead()) {
 					BufferedReader in = new BufferedReader(new FileReader(modConf.get("select").asText()));
 					String select="";

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFManagerFactory.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFManagerFactory.java
@@ -1,0 +1,32 @@
+package org.acoli.conll.rdf;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.log4j.Logger;
+
+public class CoNLLRDFManagerFactory {
+	static Logger LOG = Logger.getLogger(CoNLLRDFManagerFactory.class);
+
+	CoNLLRDFManager buildFromCLI(String[] args) throws IOException, ParseException {
+		final CoNLLRDFManager manager = new CoNLLRDFManager();
+		final CommandLine cmd = new CoNLLRDFCommandLine("CoNLLRDFManager -c JSON",
+				"Build a conll-rdf pipeline from a json configuration",
+				new Options().addRequiredOption("c", "config", true, "Specify JSON config file"), LOG).parseArgs(args);
+
+		if (cmd.hasOption("c")) {
+			try {
+				manager.readConfig(cmd.getOptionValue("c"));
+			} catch (IOException e) {
+				throw new IOException(
+						"Error when reading config file " + new File(cmd.getOptionValue("c")).getAbsolutePath(), e);
+			}
+		} else {
+			throw new ParseException("No config file specified.");
+		}
+		return manager;
+	}
+}

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFUpdater.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFUpdater.java
@@ -501,10 +501,10 @@ public class CoNLLRDFUpdater extends CoNLLRDFComponent {
 	 * 				default: threads = number of logical cores available to runtime
 	 */
 	public CoNLLRDFUpdater(String type, String path, int threads) {
-		if (type == "TDB2") {
+		if (type.equals("TDB2")) {
 			//TODO
 			dataset = DatasetFactory.create();//TDB
-		} else if (type == "TXN") {
+		} else if (type.equals("TXN")) {
 			dataset = DatasetFactory.createTxnMem();
 		} else {
 			dataset = DatasetFactory.createTxnMem();

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFUpdater.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFUpdater.java
@@ -73,10 +73,6 @@ import org.apache.log4j.Logger;
  *  @author Christian Faeth {@literal faeth@em.uni-frankfurt.de}
  */
 public class CoNLLRDFUpdater extends CoNLLRDFComponent {
-	
-	@SuppressWarnings("serial")
-	private static final List<Integer> CHECKINTERVAL = new ArrayList<Integer>() {{add(3); add(10); add(25); add(50); add(100); add(200); add(500);}};
-	static final int MAXITERATE = 999; // maximum update iterations allowed until the update loop is cancelled and an error message is thrown - to prevent faulty update scripts running in an endless loop
 	private static final Logger LOG = Logger.getLogger(CoNLLRDFUpdater.class.getName());
 	private static final String DEFAULTUPDATENAME = "DIRECTUPDATE";
 	private class UpdateThread extends Thread {
@@ -829,7 +825,8 @@ public class CoNLLRDFUpdater extends CoNLLRDFComponent {
 	 * Caches and outputs the resulting sentences in-order.
 	 * @throws IOException
 	 */
-	public void processSentenceStream() throws IOException {
+	@Override
+	protected void processSentenceStream() throws IOException {
 		running = true;
 		String line;
 		String lastLine ="";
@@ -1253,21 +1250,6 @@ public class CoNLLRDFUpdater extends CoNLLRDFComponent {
 			//READ SENTENCES from System.in  
 			updater.processSentenceStream();
 			LOG.debug((System.currentTimeMillis()-start)/1000 + " seconds");
-		}
-	}
-
-	@Override
-	public void start() {
-		run();
-	}
-
-	@Override
-	public void run() {
-		try {
-			processSentenceStream();
-		} catch (Exception e) {
-			e.printStackTrace();
-			System.exit(0);
 		}
 	}
 }

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFUpdater.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFUpdater.java
@@ -1245,9 +1245,7 @@ public class CoNLLRDFUpdater extends CoNLLRDFComponent {
 
 			long start = System.currentTimeMillis();
 
-			updater.setInputStream(new BufferedReader(new InputStreamReader(System.in)));
-			updater.setOutputStream(System.out);
-			//READ SENTENCES from System.in  
+			//READ SENTENCES from System.in
 			updater.processSentenceStream();
 			LOG.debug((System.currentTimeMillis()-start)/1000 + " seconds");
 		}

--- a/src/main/java/org/acoli/conll/rdf/CoNLLRDFUpdaterFactory.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLRDFUpdaterFactory.java
@@ -1,0 +1,105 @@
+package org.acoli.conll.rdf;
+
+import static org.acoli.conll.rdf.CoNLLRDFCommandLine.parseUpdate;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.cli.*;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.log4j.Logger;
+
+public class CoNLLRDFUpdaterFactory {
+	static Logger LOG = Logger.getLogger(CoNLLRDFUpdaterFactory.class);
+
+	public CoNLLRDFUpdater buildFromCLI(String[] args) throws IOException, ParseException {
+		CoNLLRDFUpdater updater = new CoNLLRDFUpdater();
+		final CommandLine cmd = new CoNLLRDFCommandLine(
+				"CoNLLRDFUpdater [-loglevel LEVEL] [-threads T] [-lookahead N] [-lookback N] [-custom [-model URI [GRAPH]]* [-graphsout DIR [SENT_ID ...]] [-triplesout DIR [SENT_ID ...]] -updates [UPDATE ...]]",
+				"read TTL from stdin => update CoNLL-RDF", new Option[] {
+						// Define cli options in the correct order for the help-message
+						Option.builder("loglevel").hasArg().desc("set log level to LEVEL").argName("level").build(),
+						Option.builder("threads").hasArg()
+								.desc("use T threads max\ndefault: half of available logical processor cores")
+								.type(Number.class).build(),
+						Option.builder("lookahead").hasArg().desc("cache N further sentences in lookahead graph")
+								.type(Number.class).build(),
+						Option.builder("lookback").hasArg().desc("cache N preceeding sentences in lookback graph")
+								.type(Number.class).build(),
+						new Option("prefixDeduplication", false, "Remove duplicates of TTL-Prefixes"),
+						Option.builder("custom").hasArg(false).desc("use custom update scripts")
+								./* required(). */build(),
+						Option.builder("model").hasArgs().desc("to load additional Models into local graph").build(),
+						Option.builder("graphsout").hasArgs().desc(
+								"output directory for the .dot graph files\nfollowed by the IDs of the sentences to be visualized\ndefault: first sentence only")
+								.build(),
+						Option.builder("triplesout").hasArgs()
+								.desc("same as graphsout but write N-TRIPLES for text debug instead.").build(),
+						Option.builder("updates").hasArgs()
+								.desc("followed by SPARQL scripts paired with {iterations/u}").build() },
+				CoNLLRDFUpdater.LOG).parseArgs(args);
+
+		if (cmd.hasOption("threads")) {
+			updater.setThreads(((Number) cmd.getParsedOptionValue("threads")).intValue());
+		}
+		if (cmd.hasOption("lookahead")) {
+			updater.activateLookahead(((Number) cmd.getParsedOptionValue("lookahead")).intValue());
+		}
+		if (cmd.hasOption("lookback")) {
+			updater.activateLookback(((Number) cmd.getParsedOptionValue("lookback")).intValue());
+		}
+		if (cmd.hasOption("prefixDeduplication")) {
+			updater.activatePrefixDeduplication();
+		}
+		// READ GRAPHSOUT PARAMETERS
+		if (cmd.hasOption("graphsout")) {
+			String[] graphsoutArgs = cmd.getOptionValues("graphsout");
+			String outputDir = graphsoutArgs[0];
+			List<String> outputSentences = Arrays.asList(Arrays.copyOfRange(graphsoutArgs, 1, graphsoutArgs.length));
+			updater.activateGraphsOut(outputDir, outputSentences);
+		}
+		// READ TRIPLESOUT PARAMETERS
+		if (cmd.hasOption("triplesout")) {
+			String[] triplesoutArgs = cmd.getOptionValues("triplesout");
+			String outputDir = triplesoutArgs[0];
+			List<String> outputSentences = Arrays.asList(Arrays.copyOfRange(triplesoutArgs, 1, triplesoutArgs.length));
+			updater.activateTriplesOut(outputDir, outputSentences);
+		}
+
+		if (cmd.hasOption("model")) {
+			for (Option opt : cmd.getOptions()) {
+				if (opt.getOpt().equals("model")) { // opt.equals(model)
+					String[] model = opt.getValues();
+					try {
+						if (model.length == 1) {
+							updater.loadGraph(new URI(model[0]), new URI(model[0]));
+						} else if (model.length == 2) {
+							updater.loadGraph(new URI(model[0]), new URI(model[1]));
+						} else {
+							throw new ParseException("Error while loading model: Please provide one or two URIs");
+						}
+					} catch (URISyntaxException e) {
+						throw new ParseException("Error while loading model: Could not parse given arguments as URI");
+					}
+				}
+			}
+		}
+
+		if (cmd.hasOption("updates")) {
+			List<Triple<String, String, String>> updates = new ArrayList<>();
+			for (String arg : Arrays.asList(cmd.getOptionValues("updates"))) {
+				Pair<String, String> parsed = parseUpdate(arg);
+				// should be <#UPDATEFILENAMEORSTRING, #UPDATESTRING, #UPDATEITER>
+				updates.add(new ImmutableTriple<String, String, String>(parsed.getKey(), parsed.getKey(),
+						parsed.getValue()));
+			}
+			updater.parseUpdates(updates);
+		}
+		return updater;
+	}
+}

--- a/src/main/java/org/acoli/conll/rdf/CoNLLStreamExtractor.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLStreamExtractor.java
@@ -76,7 +76,6 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 
 	@Override
 	protected void processSentenceStream() throws IOException {
-		int current_sentence = 1; // keeps track of sentence id from CoNLL2RDF
 		CoNLL2RDF conll2rdf = new CoNLL2RDF(baseURI, columns.toArray(new String[columns.size()]));
 		List<Pair<Integer,Long> > dRTs = new ArrayList<Pair<Integer,Long> >(); // iterations and execution time of each update in seconds
 		LOG.info("process input ..");
@@ -281,8 +280,8 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 		List<String> fields = new ArrayList<String>();
 		List<Pair<String, String>> updates = new ArrayList<Pair<String, String>>();
 		String select = null;
-		BufferedReader inputStream = new BufferedReader(new InputStreamReader(System.in));
-		
+		final BufferedReader inputStream = new BufferedReader(new InputStreamReader(System.in));
+
 		int i = 1;
 		while(i<argv.length && !argv[i].toLowerCase().matches("^-+u$"))
 			fields.add(argv[i++]);
@@ -373,8 +372,6 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 		ex.setColumns(fields);
 		ex.setUpdates(updates);
 		ex.setSelect(select);
-		ex.setInputStream(inputStream);
-		ex.setOutputStream(System.out);
 
 		ex.processSentenceStream();
 	}

--- a/src/main/java/org/acoli/conll/rdf/CoNLLStreamExtractor.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLStreamExtractor.java
@@ -23,6 +23,8 @@ import org.apache.jena.rdf.listeners.ChangedListener;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.update.*;
 import org.apache.log4j.Logger;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.jena.query.*;
 
 /** extracts RDF data from CoNLL files, transforms the result using SPARQL UPDATE queries,
@@ -33,27 +35,6 @@ import org.apache.jena.query.*;
  *  @author Christian Faeth {@literal faeth@em.uni-frankfurt.de}
  */
 public class CoNLLStreamExtractor extends CoNLLRDFComponent {
-	public static class Pair<F, S> {
-		public F key;
-		public S value;
-		public Pair (F key, S value) {
-			this.key = key;
-			this.value = value;
-		}
-		public F getKey() {
-			return key;
-		}
-		public void setKey(F key) {
-			this.key = key;
-		}
-		public S getValue() {
-			return value;
-		}
-		public void setValue(S value) {
-			this.value = value;
-		}
-	}
-	
 	private static Logger LOG = Logger.getLogger(CoNLLStreamExtractor.class.getName());
 	
 	@SuppressWarnings("serial")
@@ -124,7 +105,7 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 							dRTs = ret;
 						else
 							for (int x = 0; x < ret.size(); ++x)
-								dRTs.set(x, new Pair<Integer, Long>(dRTs.get(x).getKey() + ret.get(x).getKey(), dRTs.get(x).getValue() + ret.get(x).getValue()));
+								dRTs.set(x, new ImmutablePair<Integer, Long>(dRTs.get(x).getKey() + ret.get(x).getKey(), dRTs.get(x).getValue() + ret.get(x).getValue()));
 						if (comments.size() > 0) {
 							m = injectSentenceComments(m, comments);
 							comments.clear();
@@ -142,7 +123,7 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 				dRTs = ret;
 			else
 				for (int x = 0; x < ret.size(); ++x)
-					dRTs.set(x, new Pair<Integer, Long>(dRTs.get(x).getKey() + ret.get(x).getKey(), dRTs.get(x).getValue() + ret.get(x).getValue()));
+					dRTs.set(x, new ImmutablePair<Integer, Long>(dRTs.get(x).getKey() + ret.get(x).getKey(), dRTs.get(x).getValue() + ret.get(x).getValue()));
 			if (comments.size() > 0) {
 				m = injectSentenceComments(m, comments);
 				comments.clear();
@@ -256,7 +237,7 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 			}
 			if (v == MAXITERATE)
 				LOG.warn("Warning: MAXITERATE reached.");
-			result.add(new Pair<Integer, Long>(v, System.currentTimeMillis() - startTime));
+			result.add(new ImmutablePair<Integer, Long>(v, System.currentTimeMillis() - startTime));
 			m.unregister(cL);
 		}
 		return result;
@@ -320,7 +301,7 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 			else if (freq.equals("u"))
 				freq = "*";
 			String update =argv[i++].replaceFirst("\\{[0-9*]+\\}$", "");
-			updates.add(new Pair<String, String>(update, freq));
+			updates.add(new ImmutablePair<String, String>(update, freq));
 		}
 		while(i<argv.length && argv[i].toLowerCase().matches("^-+s$")) i++;
 		if(i<argv.length)
@@ -359,10 +340,10 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 				} catch (Exception e) {}
 			}
 
-			updates.set(i,new Pair<String, String>("", updates.get(i).getValue()));
+			updates.set(i,new ImmutablePair<String, String>("", updates.get(i).getValue()));
 			BufferedReader in = new BufferedReader(sparqlreader);
 			for(String line = in.readLine(); line!=null; line=in.readLine())
-				updates.set(i,new Pair<String, String>(updates.get(i).getKey()+line+"\n",updates.get(i).getValue()));
+				updates.set(i,new ImmutablePair<String, String>(updates.get(i).getKey()+line+"\n",updates.get(i).getValue()));
 			sb.append(".");
 		}
 		sb.append(".");

--- a/src/main/java/org/acoli/conll/rdf/CoNLLStreamExtractor.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLStreamExtractor.java
@@ -36,13 +36,6 @@ import org.apache.jena.query.*;
  */
 public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 	private static Logger LOG = Logger.getLogger(CoNLLStreamExtractor.class.getName());
-	
-	@SuppressWarnings("serial")
-	private static List<Integer> CHECKINTERVAL = new ArrayList<Integer>() {{add(3); add(10); add(25); add(50); add(100); add(200); add(500);}};
-
-	static final int MAXITERATE = 999; // maximal update iterations allowed until the update loop is canceled and an error msg is thrown - to prevent faulty update scripts running in an endless loop
-	
-	
 	private String baseURI;
 	public String getBaseURI() {
 		return baseURI;
@@ -80,8 +73,9 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 	private List<String> columns = new ArrayList<String>(); 
 	private String select = null;
 	List<Pair<String, String>> updates = new ArrayList<Pair<String, String>>();
-	
-	protected void processSentenceStream() throws Exception {
+
+	@Override
+	protected void processSentenceStream() throws IOException {
 		int current_sentence = 1; // keeps track of sentence id from CoNLL2RDF
 		CoNLL2RDF conll2rdf = new CoNLL2RDF(baseURI, columns.toArray(new String[columns.size()]));
 		List<Pair<Integer,Long> > dRTs = new ArrayList<Pair<Integer,Long> >(); // iterations and execution time of each update in seconds
@@ -370,10 +364,9 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 			select="";
 			for(String line = in.readLine(); line!=null; line=in.readLine())
 				select=select+line+"\n";
-		}		
+		}
 		sb.append(". ok");
 		LOG.info(sb.toString());
-		
 
 		CoNLLStreamExtractor ex = new CoNLLStreamExtractor();
 		ex.setBaseURI(baseURI);
@@ -382,24 +375,7 @@ public class CoNLLStreamExtractor extends CoNLLRDFComponent {
 		ex.setSelect(select);
 		ex.setInputStream(inputStream);
 		ex.setOutputStream(System.out);
-		
-		ex.processSentenceStream();
-		
-	}
-	
-	
-	@Override
-	public void run() {
-		try {
-			processSentenceStream();
-		} catch (Exception e) {
-			e.printStackTrace();
-			System.exit(0);
-		}
-	}
 
-	@Override
-	public void start() {
-		run();
+		ex.processSentenceStream();
 	}
 }

--- a/src/main/java/org/acoli/conll/rdf/CoNLLStreamExtractorFactory.java
+++ b/src/main/java/org/acoli/conll/rdf/CoNLLStreamExtractorFactory.java
@@ -1,0 +1,70 @@
+package org.acoli.conll.rdf;
+
+import static org.acoli.conll.rdf.CoNLLRDFCommandLine.parseSelectOptionLegacy;
+
+import java.io.*;
+import java.util.*;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.tuple.*;
+import org.apache.log4j.Logger;
+
+public class CoNLLStreamExtractorFactory {
+	static Logger LOG = Logger.getLogger(CoNLLStreamExtractorFactory.class);
+	public CoNLLStreamExtractor buildFromCLI(String[] args) throws IOException, ParseException {
+		CoNLLStreamExtractor extractor = new CoNLLStreamExtractor();
+		//FIXME
+		List<Pair<String, String>> updates = new ArrayList<Pair<String, String>>();
+
+		final CommandLine cmd = new CoNLLRDFCommandLine("synopsis: CoNLLStreamExtractor baseURI FIELD1[.. FIELDn] [-u SPARQL_UPDATE1..m] [-s SPARQL_SELECT]\n"
+		+ "\tbaseURI       CoNLL base URI, cf. CoNLL2RDF\n"
+		+ "\tFIELDi        CoNLL field label, cf. CoNLL2RDF",
+		"reads CoNLL from stdin, splits sentences, creates CoNLL RDF, applies SPARQL queries",
+		new Option[] {
+			Option.builder("s").hasArg().hasArgs().desc("SPARQL SELECT statement to produce TSV output").build(),
+			Option.builder("u").hasArgs().argName("sparql_update").desc("DEPRECATED - please use CoNLLRDFUpdater instead!").build()
+			/* "SPARQL_UPDATE SPARQL UPDATE (DELETE/INSERT) query, either literally or its location (file/uri).
+			Can be followed by an optional integer in {}-parentheses = number of repetitions" */
+		}, LOG).parseArgs(args);
+
+		List<String> argList = cmd.getArgList();
+		if (argList.isEmpty()) {
+			throw new ParseException("Missing required Argument baseURI");
+		}
+		extractor.setBaseURI(argList.remove(0));
+		/* TODO Store the Columns provided as arguments seperate from the variable used by the thread.
+		Status quo: It's  difficult to test for special cases with argument-provided column labels and conll-u plus comments
+		*/
+
+		// Iff argList doesn't contain any columns, processSentenceStream() will call findColumnsFromComment().
+		if (argList.isEmpty()) {
+			extractor.setReadColumnComment(true);
+		} else {
+			extractor.setColumns(argList);
+		}
+
+		if (cmd.hasOption("s")) {
+			String sparqlStringOrFile = String.join(" ", Arrays.asList(cmd.getOptionValues("s")));
+			LOG.debug("-s option was set with " + sparqlStringOrFile);
+			extractor.setSelect(parseSelectOptionLegacy(sparqlStringOrFile));
+		}
+
+		if (cmd.hasOption("u")) {
+			LOG.warn("using -u to provide updates is deprecated");
+			for (String arg : cmd.getOptionValues("u")) {
+				Pair<String, String> update = extractor.parseUpdate(arg);
+				updates.add(new ImmutablePair<String, String>(extractor.parseSparqlArg(update.getKey()), update.getValue()));
+				extractor.setUpdates(updates);
+				// FIXME
+			}
+		}
+
+		LOG.info("running CoNLLStreamExtractor");
+		LOG.info("\tbaseURI:       " + extractor.getBaseURI());
+		LOG.info("\tCoNLL columns: " + extractor.getColumns());
+
+		return extractor;
+	}
+}

--- a/src/main/java/org/acoli/conll/rdf/SimpleLineBreakSplitter.java
+++ b/src/main/java/org/acoli/conll/rdf/SimpleLineBreakSplitter.java
@@ -1,11 +1,9 @@
 package org.acoli.conll.rdf;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 
 public class SimpleLineBreakSplitter extends CoNLLRDFComponent {
-
+	@Override
 	protected void processSentenceStream() throws IOException {
 		String line;
 		int empty = 0;
@@ -28,9 +26,6 @@ public class SimpleLineBreakSplitter extends CoNLLRDFComponent {
 		SimpleLineBreakSplitter splitter = new SimpleLineBreakSplitter();
 
 		long start = System.currentTimeMillis();
-
-		splitter.setInputStream(new BufferedReader(new InputStreamReader(System.in)));
-		splitter.setOutputStream(System.out);
 
 		//READ SENTENCES from System.in
 		splitter.processSentenceStream();

--- a/src/main/java/org/acoli/conll/rdf/SimpleLineBreakSplitter.java
+++ b/src/main/java/org/acoli/conll/rdf/SimpleLineBreakSplitter.java
@@ -6,8 +6,7 @@ import java.io.InputStreamReader;
 
 public class SimpleLineBreakSplitter extends CoNLLRDFComponent {
 
-
-	private void processSentenceStream() throws IOException {
+	protected void processSentenceStream() throws IOException {
 		String line;
 		int empty = 0;
 		while((line = getInputStream().readLine())!=null) {
@@ -24,21 +23,6 @@ public class SimpleLineBreakSplitter extends CoNLLRDFComponent {
 		getOutputStream().close();
 	}
 
-	@Override
-	public void run() {
-		try {
-			processSentenceStream();
-		} catch (Exception e) {
-			e.printStackTrace();
-			System.exit(0);
-		}
-	}
-
-	@Override
-	public void start() {
-		run();
-	}
-
 	public static void main(String[] args) throws IOException {
 		System.err.println("synopsis: SimpleLineBreakSplitter");
 		SimpleLineBreakSplitter splitter = new SimpleLineBreakSplitter();
@@ -52,5 +36,4 @@ public class SimpleLineBreakSplitter extends CoNLLRDFComponent {
 		splitter.processSentenceStream();
 		System.err.println(((System.currentTimeMillis()-start)/1000 + " seconds"));
 	}
-
 }

--- a/src/main/java/org/acoli/conll/rdf/SimpleLineBreakSplitter.java
+++ b/src/main/java/org/acoli/conll/rdf/SimpleLineBreakSplitter.java
@@ -3,8 +3,11 @@ package org.acoli.conll.rdf;
 import java.io.IOException;
 
 import org.apache.commons.cli.ParseException;
+import org.apache.log4j.Logger;
 
 public class SimpleLineBreakSplitter extends CoNLLRDFComponent {
+	static final Logger LOG = Logger.getLogger(SimpleLineBreakSplitter.class);
+
 	@Override
 	protected void processSentenceStream() throws IOException {
 		String line;
@@ -28,13 +31,18 @@ public class SimpleLineBreakSplitter extends CoNLLRDFComponent {
 	}
 
 	public static void main(String[] args) throws IOException {
-		System.err.println("synopsis: SimpleLineBreakSplitter");
 		SimpleLineBreakSplitter splitter = new SimpleLineBreakSplitter();
 
-		long start = System.currentTimeMillis();
+		try {
+			splitter.configureFromCommandLine(args);
+		} catch (ParseException e) {
+			LOG.error(e);
+			System.exit(1);
+		}
 
-		//READ SENTENCES from System.in
+		long start = System.currentTimeMillis();
+		// READ SENTENCES from System.in
 		splitter.processSentenceStream();
-		System.err.println(((System.currentTimeMillis()-start)/1000 + " seconds"));
+		LOG.info((System.currentTimeMillis() - start) / 1000 + " seconds");
 	}
 }

--- a/src/main/java/org/acoli/conll/rdf/SimpleLineBreakSplitter.java
+++ b/src/main/java/org/acoli/conll/rdf/SimpleLineBreakSplitter.java
@@ -2,6 +2,8 @@ package org.acoli.conll.rdf;
 
 import java.io.IOException;
 
+import org.apache.commons.cli.ParseException;
+
 public class SimpleLineBreakSplitter extends CoNLLRDFComponent {
 	@Override
 	protected void processSentenceStream() throws IOException {
@@ -19,6 +21,10 @@ public class SimpleLineBreakSplitter extends CoNLLRDFComponent {
 			}
 		}
 		getOutputStream().close();
+	}
+
+	public void configureFromCommandLine(String[] args) throws IOException, ParseException {
+		// Nothing to do
 	}
 
 	public static void main(String[] args) throws IOException {

--- a/src/test/java/org/acoli/conll/rdf/CoNLLRDFCommandLineTest.java
+++ b/src/test/java/org/acoli/conll/rdf/CoNLLRDFCommandLineTest.java
@@ -1,0 +1,100 @@
+package org.acoli.conll.rdf;
+
+import static org.acoli.conll.rdf.CoNLLRDFCommandLine.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class CoNLLRDFCommandLineTest {
+	private static final Logger LOG = Logger.getLogger(CoNLLRDFCommandLineTest.class);
+
+	@Test
+	void silentOption() throws ParseException {
+		Logger logger = Logger.getLogger("silentOption");
+		CoNLLRDFCommandLine conllCli = new CoNLLRDFCommandLine("syntax", "description", new Option[] {}, logger);
+
+		conllCli.parseArgs(new String[] { "-silent" });
+
+		assertEquals(Level.WARN, logger.getLevel());
+	}
+
+	@Test
+	@Disabled("Unimplemented test")
+	void helpOption() throws ParseException {
+		// TODO implement test
+	}
+
+	@Test
+	public void parseUpdateArg() throws IOException, ParseException {
+		assertEquals(new ImmutablePair<String, String>("aaa", "1"), parseUpdate("aaa"));
+		assertEquals(new ImmutablePair<String, String>("aaa", "1"), parseUpdate("aaa{1}"));
+		assertEquals(new ImmutablePair<String, String>("aaa", "*"), parseUpdate("aaa{*}"));
+		assertEquals(new ImmutablePair<String, String>("aaa", "*"), parseUpdate("aaa{u}"));
+	}
+
+	@Test
+	public void readSparqlFileArg() throws IOException {
+		selectQueryFromLiteral(readSparqlFile("examples/sparql/select-sentence-strings.sparql"));
+		readSparqlSelect("examples/sparql/select-sentence-strings.sparql");
+		selectQueryFromLiteral(readUrl(new URL(
+				"https://raw.githubusercontent.com/acoli-repo/conll-rdf/master/examples/sparql/select-sentence-strings.sparql")));
+		readSparqlSelect(
+				"https://raw.githubusercontent.com/acoli-repo/conll-rdf/master/examples/sparql/select-sentence-strings.sparql");
+	}
+
+	@Test
+	public void preserveOrder() {
+		Options optionsA = new Options().addOption("help", false, "print this help message and exit")
+				.addOption("silent", false, "supress help message and logging of info messages");
+		Options optionsB = new Options()
+				.addOption(Option.builder("rdf").hasArgs().optionalArg(true)
+						.desc("write formatted CoNLL-RDF to stdout (sorted by list of CoNLL COLS, if provided)")
+						.build())
+				.addOption(Option.builder("conll").hasArgs().optionalArg(true)
+						.desc("write formatted CoNLL to stdout (only specified COLS)").build())
+				.addOption("debug", false, "write formatted, color-highlighted full turtle to stderr")
+				.addOption("grammar", false, "write CoNLL data structures to stdout")
+				.addOption("semantics", false, "write semantic graph to stdout").addOption("sparqltsv", true,
+						"write TSV generated from SPARQL statement to stdout.\nif with -grammar, then skip type assignments");
+		Iterator<Option> it = optionsB.getOptions().iterator();
+		while (it.hasNext()) {
+			optionsA.addOption(it.next());
+		}
+		LOG.debug(optionsA.toString());
+	}
+
+	@Test
+	public void multiOptions() throws ParseException {
+		Option model = Option.builder("model").hasArg().hasArgs().build();
+		final Options options = new Options().addOption(model).addOption("dummy", false, "description");
+		final CoNLLRDFCommandLine conllCli = new CoNLLRDFCommandLine("syntax", "description", options, LOG);
+		CommandLine cmd = conllCli.parseArgs(new String[] { "-model", "a", "b", "-model", "c", "-dummy" });
+
+		List<String[]> thatOption = new ArrayList<String[]>();
+		for (Option opt : cmd.getOptions()) {
+			LOG.debug("opt: " + opt.getOpt());
+			LOG.debug("equals: " + opt.equals(model));
+			if (opt.getOpt().equals("model")) {
+				LOG.debug(Arrays.asList(opt.getValues()).toString());
+				thatOption.add(opt.getValues());
+			}
+		}
+		LOG.debug(thatOption.size());
+		LOG.debug(Arrays.asList(thatOption).toString());
+	}
+}

--- a/src/test/java/org/acoli/conll/rdf/CoNLLRDFFormatterFactoryTest.java
+++ b/src/test/java/org/acoli/conll/rdf/CoNLLRDFFormatterFactoryTest.java
@@ -1,0 +1,110 @@
+package org.acoli.conll.rdf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedList;
+
+import org.apache.commons.cli.ParseException;
+import org.junit.jupiter.api.Test;
+import org.acoli.conll.rdf.CoNLLRDFFormatter.Mode;
+
+public class CoNLLRDFFormatterFactoryTest {
+	// rdf COLS
+	@Test
+	void rdfOptionNoColumns() throws IOException, ParseException {
+		CoNLLRDFFormatter formatter = new CoNLLRDFFormatterFactory().buildFromCLI(new String[] { "-rdf" });
+		assertEquals(Mode.CONLLRDF, formatter.getModules().get(0).getMode());
+	}
+
+	@Test
+	void rdfOption() throws IOException, ParseException {
+		CoNLLRDFFormatter formatter = new CoNLLRDFFormatterFactory().buildFromCLI(new String[] { "-rdf", "WORD", "POS" });
+		assertEquals(Mode.CONLLRDF, formatter.getModules().get(0).getMode());
+		assertEquals(new LinkedList<String>(Arrays.asList("WORD", "POS")), formatter.getModules().get(0).getCols());
+	}
+
+	// conll COLS
+	@Test
+	void conllOptionNoColumns() throws IOException, ParseException {
+		CoNLLRDFFormatter formatter = new CoNLLRDFFormatterFactory().buildFromCLI(new String[] { "-conll" });
+		assertEquals(Mode.CONLL, formatter.getModules().get(0).getMode());
+	}
+
+	@Test
+	void conllOption() throws IOException, ParseException {
+		CoNLLRDFFormatter formatter = new CoNLLRDFFormatterFactory().buildFromCLI(new String[] { "-conll", "WORD", "POS" });
+		assertEquals(Mode.CONLL, formatter.getModules().get(0).getMode());
+		assertEquals(new LinkedList<String>(Arrays.asList("WORD", "POS")), formatter.getModules().get(0).getCols());
+	}
+
+	// debug
+	@Test
+	void debugOption() throws IOException, ParseException {
+		CoNLLRDFFormatter formatter = new CoNLLRDFFormatterFactory().buildFromCLI(new String[] { "-debug" });
+		assertEquals(Mode.DEBUG, formatter.getModules().get(0).getMode());
+	}
+
+	// grammar
+	@Test
+	void grammarOption() throws IOException, ParseException {
+		CoNLLRDFFormatter formatter = new CoNLLRDFFormatterFactory().buildFromCLI(new String[] { "-grammar" });
+		assertEquals(Mode.GRAMMAR, formatter.getModules().get(0).getMode());
+	}
+
+	// semantics
+	@Test
+	void semanticsOption() throws IOException, ParseException {
+		CoNLLRDFFormatter formatter = new CoNLLRDFFormatterFactory().buildFromCLI(new String[] { "-semantics" });
+		assertEquals(Mode.SEMANTICS, formatter.getModules().get(0).getMode());
+	}
+
+	// query (sparqltsv) SPARQL
+	// TODO test with url
+	@Test
+	void queryOption() throws IOException, ParseException {
+		CoNLLRDFFormatter formatter = new CoNLLRDFFormatterFactory().buildFromCLI(new String[] { "-query", "Some Query here" });
+		assertEquals(Mode.QUERY, formatter.getModules().get(0).getMode());
+		assertEquals("Some Query here", formatter.getModules().get(0).getSelect());
+	}
+
+	@Test
+	void queryOptionFile() throws IOException, ParseException {
+		CoNLLRDFFormatter formatter = new CoNLLRDFFormatterFactory().buildFromCLI(new String[] { "-query", "src/test/resources/select-test.sparql" });
+		assertEquals(Mode.QUERY, formatter.getModules().get(0).getMode());
+		assertEquals("SELECT ?subject ?predicate ?object WHERE {?subject ?predicate ?object .}", formatter.getModules().get(0).getSelect());
+	}
+
+	// -sparqltsv is deprecated
+	@Test
+	void sparqltsvOption() throws IOException, ParseException {
+		CoNLLRDFFormatter formatter = new CoNLLRDFFormatterFactory().buildFromCLI(new String[] { "-sparqltsv", "Some Query Here" });
+		assertEquals(Mode.QUERY, formatter.getModules().get(0).getMode());
+		assertEquals("Some Query Here", formatter.getModules().get(0).getSelect().trim());
+	}
+	// grammar + query
+
+	@Test
+	void GrammarSemanticsOption() throws IOException, ParseException {
+		CoNLLRDFFormatter formatter = new CoNLLRDFFormatterFactory().buildFromCLI(new String[] { "-grammar", "-semantics"});
+		assertEquals(Mode.GRAMMAR_SEMANTICS, formatter.getModules().get(0).getMode());
+	}
+
+	// if no parameters are supplied, -conllrdf is inferred
+	@Test
+	void noOption() throws IOException, ParseException {
+		CoNLLRDFFormatter formatter = new CoNLLRDFFormatterFactory().buildFromCLI(new String[] {});
+		assertEquals(Mode.CONLLRDF, formatter.getModules().get(0).getMode());
+	}
+
+	// column label with dash in cli args
+	@Test
+	void conllOptionWithDashInQuery() throws ParseException, IOException {
+		CoNLLRDFFormatter formatter = new CoNLLRDFFormatterFactory()
+				.buildFromCLI(new String[] { "-conll", "WORD", "POS", "PARSE", "NER", "COREF", "PRED", "PRED-ARGS" });
+
+		assertEquals(new LinkedList<String>(Arrays.asList("WORD", "POS", "PARSE", "NER", "COREF", "PRED", "PRED-ARGS")),
+				formatter.getModules().get(0).getCols());
+	}
+}

--- a/src/test/java/org/acoli/conll/rdf/CoNLLRDFManagerFactoryTest.java
+++ b/src/test/java/org/acoli/conll/rdf/CoNLLRDFManagerFactoryTest.java
@@ -1,0 +1,25 @@
+package org.acoli.conll.rdf;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+
+import org.apache.commons.cli.ParseException;
+import org.junit.jupiter.api.Test;
+
+public class CoNLLRDFManagerFactoryTest {
+    // throw ParseException if no arguments are provided
+    @Test
+    void noOption() throws IOException, ParseException {
+        assertThrows(ParseException.class, () -> {
+            new CoNLLRDFManagerFactory().buildFromCLI(new String[] {});
+        });
+    }
+
+    @Test
+    void noConfigFile() throws IOException, ParseException {
+        assertThrows(ParseException.class, () -> {
+            new CoNLLRDFManagerFactory().buildFromCLI(new String[] {"-c"});
+        });
+    }
+}

--- a/src/test/java/org/acoli/conll/rdf/CoNLLRDFUpdaterFactoryTest.java
+++ b/src/test/java/org/acoli/conll/rdf/CoNLLRDFUpdaterFactoryTest.java
@@ -1,0 +1,189 @@
+package org.acoli.conll.rdf;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.*;
+
+import org.apache.commons.cli.ParseException;
+import org.apache.log4j.Level;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class CoNLLRDFUpdaterFactoryTest {
+	// throw ParseException if no arguments are provided
+	@Test
+	void noOption() throws IOException, ParseException {
+		assertThrows(ParseException.class, () -> {
+			new CoNLLRDFManagerFactory().buildFromCLI(new String[] {});
+		});
+	}
+
+	// loglevel
+	@Test
+	void setLoglevel() throws IOException, ParseException {
+		new CoNLLRDFUpdaterFactory().buildFromCLI(new String[] { "-loglevel", "TRACE" });
+		assertEquals(Level.TRACE, CoNLLRDFUpdater.LOG.getLevel());
+		new CoNLLRDFUpdaterFactory().buildFromCLI(new String[] { "-loglevel", "DEBUG" });
+		assertEquals(Level.DEBUG, CoNLLRDFUpdater.LOG.getLevel());
+	}
+
+	@Disabled("log4j Level.toLevel method defaults to DEBUG. No Exception is thrown.")
+	@Test
+	void invalidLoglevel() throws IOException, ParseException {
+		assertThrows(ParseException.class, () -> {
+			new CoNLLRDFUpdaterFactory().buildFromCLI(new String[] { "-loglevel", "FOO" });
+		});
+	}
+
+	// threads
+	@Test
+	void setThreads() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory().buildFromCLI(new String[] { "-threads", "9" });
+		assertEquals(9, updater.getThreads());
+	}
+
+	// lookahead
+	@Test
+	void setLookahead() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory().buildFromCLI(new String[] { "-lookahead", "4" });
+		assertEquals(4, updater.getLookahead());
+	}
+
+	// lookback
+	@Test
+	void setLookback() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory().buildFromCLI(new String[] { "-lookback", "7" });
+		assertEquals(7, updater.getLookback());
+	}
+
+	// prefixDeduplication
+	@Test
+	void setPrefixDeduplication() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory().buildFromCLI(new String[] { "-prefixDeduplication" });
+		assertEquals(true, updater.getPrefixDeduplication());
+	}
+
+	@Test
+	void unsetPrefixDeduplication() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory().buildFromCLI(new String[] {});
+		assertEquals(false, updater.getPrefixDeduplication());
+	}
+
+	// custom
+	@Test
+	void setCustom() throws IOException, ParseException {
+		new CoNLLRDFUpdaterFactory().buildFromCLI(new String[] { "-custom" });
+	}
+
+	// model
+	@Test
+	void setModel() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory()
+				.buildFromCLI(new String[] { "-model", "http://purl.org/olia/penn.owl" });
+		assertTrue(updater.hasGraph("http://purl.org/olia/penn.owl"));
+	}
+
+	@Test
+	void setModelWithName() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory()
+				.buildFromCLI(new String[] { "-model", "http://purl.org/olia/penn.owl", "http://localhost" });
+		assertTrue(updater.hasGraph("http://localhost"));
+	}
+
+	// TODO test with model from local File
+	/* @Test
+	void setModelFromFile() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory()
+				.getUpdater(new String[] { "-model", "http://purl.org/olia/penn.owl", "http://localhost" });
+		assertTrue(updater.hasGraph("http://localhost"));
+	}*/
+
+	// graphsout
+	// TODO use junit5's @TempDir for the tests producing files
+	@Test
+	void setGraphsout() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory()
+				.buildFromCLI(new String[] { "-graphsout", "graphsdir", "sentence_id1" });
+		assertEquals(new File("graphsdir"), updater.getGraphOutputDir());
+		assertArrayEquals(new String[] { "sentence_id1" }, updater.getGraphOutputSentences());
+	}
+
+	@Test
+	void setManyGraphsout() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory()
+				.buildFromCLI(new String[] { "-graphsout", "graphsdir", "sentence_id1", "sentence_id2" });
+		assertArrayEquals(new String[] { "sentence_id1", "sentence_id2" }, updater.getGraphOutputSentences());
+	}
+
+	@Test
+	void setGraphsoutWithoutID() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory().buildFromCLI(new String[] { "-graphsout", "graphsdir" });
+		assertArrayEquals(new String[] {}, updater.getGraphOutputSentences());
+		assertNotNull(updater.getGraphOutputDir());
+		// Stream<String> inputStream = Stream.of("");
+		String rdfSentence = "@prefix : <https://github.com/acoli-repo/conll-rdf#> ."
+				+ "\n@prefix nif: <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> ."
+				+ "\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ." + "\n:s1_0 a nif:Sentence ."
+				+ "\n:s2_0 a nif:Sentence .";
+		updater.setInputStream(new BufferedReader(new StringReader(rdfSentence)));
+		updater.processSentenceStream();
+		assertArrayEquals(new String[] { "s1_0" }, updater.getGraphOutputSentences());
+	}
+
+	// triplesout
+	@Test
+	void setTriplesout() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory()
+				.buildFromCLI(new String[] { "-triplesout", "triplesdir", "sentence_id1" });
+		assertEquals(new File("triplesdir"), updater.getTriplesOutputDir());
+		assertArrayEquals(new String[] { "sentence_id1" }, updater.getTriplesOutputSentences());
+	}
+
+	@Test
+	void setManyTriplesout() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory()
+				.buildFromCLI(new String[] { "-triplesout", "triplesdir", "sentence_id1", "sentence_id2" });
+		assertArrayEquals(new String[] { "sentence_id1", "sentence_id2" }, updater.getTriplesOutputSentences());
+	}
+
+	@Test
+	void setTriplesoutWithoutID() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory().buildFromCLI(new String[] { "-triplesout", "triplesdir" });
+		assertArrayEquals(new String[] {}, updater.getTriplesOutputSentences());
+		assertNotNull(updater.getTriplesOutputDir());
+		// Stream<String> inputStream = Stream.of("");
+		String rdfSentence = "@prefix : <https://github.com/acoli-repo/conll-rdf#> ."
+				+ "\n@prefix nif: <http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> ."
+				+ "\n@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ." + "\n:s1_0 a nif:Sentence ."
+				+ "\n:s2_0 a nif:Sentence .";
+		updater.setInputStream(new BufferedReader(new StringReader(rdfSentence)));
+		updater.processSentenceStream();
+		assertArrayEquals(new String[] { "s1_0" }, updater.getTriplesOutputSentences());
+	}
+
+	// updates
+	@Test
+	void setUpdate() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory()
+				.buildFromCLI(new String[] { "-updates", "examples/sparql/remove-IGNORE.sparql" });
+		assertArrayEquals(new String[] { "examples/sparql/remove-IGNORE.sparql" }, updater.getUpdateNames());
+		assertArrayEquals(new String[] { "1" }, updater.getUpdateMaxIterations());
+	}
+
+	@Test
+	void setUpdates() throws IOException, ParseException {
+		final CoNLLRDFUpdater updater = new CoNLLRDFUpdaterFactory().buildFromCLI(new String[] { "-updates",
+				"examples/sparql/remove-IGNORE.sparql{u}", "examples/sparql/remove-ID.sparql" });
+		assertArrayEquals(new String[] { "examples/sparql/remove-IGNORE.sparql", "examples/sparql/remove-ID.sparql" },
+				updater.getUpdateNames());
+		assertArrayEquals(new String[] { "*", "1" }, updater.getUpdateMaxIterations());
+	}
+
+	// graphsout
+	@Test
+	void invalidGraphsout() throws IOException, ParseException {
+		assertThrows(ParseException.class, () -> {
+			new CoNLLRDFUpdaterFactory().buildFromCLI(new String[] { "-graphsout" });
+		});
+	}
+}

--- a/src/test/java/org/acoli/conll/rdf/CoNLLStreamExtractorFactoryTest.java
+++ b/src/test/java/org/acoli/conll/rdf/CoNLLStreamExtractorFactoryTest.java
@@ -1,0 +1,92 @@
+package org.acoli.conll.rdf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.log4j.Logger;
+import org.junit.jupiter.api.Test;
+
+public class CoNLLStreamExtractorFactoryTest {
+	static Logger LOG = Logger.getLogger(CoNLLStreamExtractorFactoryTest.class);
+
+	// throw ParseException if no arguments are provided
+    @Test
+    void noOption() throws IOException, ParseException {
+        assertThrows(ParseException.class, () -> {
+            new CoNLLRDFManagerFactory().buildFromCLI(new String[] {});
+        });
+    }
+
+	// column label (with dash) in cli-args
+	@Test
+	void CoNLLColumnLabelWithDash() throws ParseException, IOException {
+		CoNLLStreamExtractor extractor = new CoNLLStreamExtractorFactory().buildFromCLI(
+				new String[] { "url", "WORD", "POS", "PARSE", "NER", "COREF", "PRED", "PRED-ARGS" });
+
+		assertEquals("url", extractor.getBaseURI());
+		assertEquals(new LinkedList<String>(Arrays.asList("WORD", "POS", "PARSE", "NER", "COREF", "PRED", "PRED-ARGS")),
+				extractor.getColumns());
+	}
+
+	// column label with dash in first line
+	@Test
+	void CoNLLUPlusStyleColumnLabelWithDash() throws ParseException, IOException {
+		CoNLLStreamExtractor extractor = new CoNLLStreamExtractorFactory().buildFromCLI(new String[] { "url" });
+		extractor.setInputStream(
+				new BufferedReader(new StringReader("# global.columns = WORD POS PARSE NER COREF PRED PRED-ARGS \n\n")));
+		extractor.findColumnsFromComment();
+		assertEquals("url", extractor.getBaseURI());
+		assertEquals(new LinkedList<String>(Arrays.asList("WORD", "POS", "PARSE", "NER", "COREF", "PRED", "PRED-ARGS")),
+				extractor.getColumns());
+		extractor.getInputStream().close();
+	}
+
+	// deprecated update
+	@Test
+	void optionUpdate() throws ParseException, IOException {
+		CoNLLStreamExtractor extractor = new CoNLLStreamExtractorFactory().buildFromCLI(new String [] {
+			"url", "WORD", "POS", "PARSE", "NER", "COREF", "PRED", "PRED-ARGS", "-u", "example/sparql/remove-ID.sparql"});
+		extractor.setInputStream(
+				new BufferedReader(new StringReader("\n\n")));
+		List<Pair<String, String>> actualUpdates = extractor.getUpdates();
+		assertEquals(1, actualUpdates.size());
+		assertEquals("example/sparql/remove-ID.sparql\n", actualUpdates.get(0).getLeft());
+		assertEquals("1", actualUpdates.get(0).getRight());
+		extractor.processSentenceStream();
+
+		// TODO test if the file is loaded properly
+	}
+
+	@Test
+	void optionUpdateWithIterations() throws ParseException, IOException {
+		CoNLLStreamExtractor extractor = new CoNLLStreamExtractorFactory().buildFromCLI(new String [] {
+			"url", "WORD", "POS", "PARSE", "NER", "COREF", "PRED", "PRED-ARGS", "-u", "example/sparql/remove-ID.sparql{2}"});
+		extractor.setInputStream(
+				new BufferedReader(new StringReader("\n\n")));
+		List<Pair<String, String>> actualUpdates = extractor.getUpdates();
+		assertEquals(1, actualUpdates.size());
+		assertEquals("example/sparql/remove-ID.sparql\n", actualUpdates.get(0).getLeft());
+		assertEquals("2", actualUpdates.get(0).getRight());
+	}
+
+	// select
+	// TODO Add test cases for URL and literal (after refactor)
+	@Test
+	void optionSelect() throws ParseException, IOException {
+		CoNLLStreamExtractor extractor = new CoNLLStreamExtractorFactory().buildFromCLI(new String [] {"url", "-s", "src/test/resources/select-test.sparql"});
+		// TODO Use Resource
+		// File expectedFile = this.getClass().getResource("select-conllu.sparql").getFile();
+		String expected = "SELECT ?subject ?predicate ?object WHERE {?subject ?predicate ?object .}\n";
+
+		assertEquals(expected, extractor.getSelect());
+	}
+}

--- a/src/test/resources/select-test.sparql
+++ b/src/test/resources/select-test.sparql
@@ -1,0 +1,1 @@
+SELECT ?subject ?predicate ?object WHERE {?subject ?predicate ?object .}


### PR DESCRIPTION
Goals of this PR
---
- [x] Formatter: Allow collumn labels with dashes in them. Fix #29 
- [x] When provided invalid arguments, all classes should fail with a helpful error, and not a stack trace. Fix #30 
  - [x] Gracefully deal with parsing exceptions, and other exceptions resulting from bad arguments
- [x] Formatter: Deprecate -sparqltsv in favor of -query. Fix #33 
  - [x] documentation
  - [x] example scripts
- [x] Implement a -silent flag for all classes. Fix #39 
  - [x] documentation
- [x] Unit-Tests for command line parsing
- [x] Implement Parsing of CommandLine Options with CommonsCli (including help-message)
  - [x] Properly implement all flags that can have 0 or many arguments
---
- [x] CoNLLRDFManager
  - [x] Factory-Class
  - [x] fully using CommonsCli
  - ~~[ ] Test-Class~~
- [x] CoNLLStreamExtractor
  - [x] Factory-Class
  - [x] fully using CommonsCli
  - [x] Test-Class
- [x] CoNLLRDFUpdater
  - [x] Factory-Class
  - [x] fully using CommonsCli
  - [x] Test-Class
- [x] CoNLLRDFFormatter
  - [x] Factory-Class
  - [x] fully using CommonsCli
  - [x] Test-Class
- [x] CoNLLRDFAnnotator
  - ~~[ ] Factory-Class~~
  - [x] fully using CommonsCli
  - ~~[ ] Test-Class~~
- [x] Clean up remaining todos
- [x] Rename Factory methods to  buildFromCLI(), make non-static
- [x] Fix all main methods
- [x] Fix #53 

#### then
- [x] Rebase onto main-branch
- ~~[ ] copyright message?~~
- [x] interactive rebase (squash)
- [x] passes all tests (except for 2 unimplemented and disabled tests)
#### lastly
- [x] Remove WIP
