### PR TITLE
Add Feature: Package as jar with dependencies

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -9,4 +9,4 @@
 
 conll_dir="$(dirname -- "$(realpath -- "$0")")"
 
-mvn clean compile -am --batch-mode --quiet  "--file=${conll_dir}" -e
+mvn clean compile -am --batch-mode --quiet  "--file=${conll_dir}" -e -DskipTests=true

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Package the Conll-rdf project as a jar-with-dependencies
+# Please read the notice at the start of run.sh if you're not sure what you're seeing here.
+
+# store the path of the conll-rdf directory
+conll_dir="$(dirname -- "$(realpath -- "$0")")"
+
+# Package conll-rdf as a jar-with dependencies, which can then be run as follows:
+# java -cp target/conll-rdf-1.0-SNAPSHOT-jar-with-dependencies.jar org.acoli.conll.rdf.CoNLLStreamExtractor uri id word
+# Make sure JAVA_HOME is set to the correct version while compiling, if encountering errors like class not found
+mvn clean compile package --batch-mode --quiet --file="${conll_dir}" -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,11 @@
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>
-          <!--<archive>
-            <manifest>
-              <mainClass>org.acoli.conll.rdf.CoNLLRDFCli</mainClass>
-            </manifest>
-          </archive>-->
+          <archive>
+            <manifestEntries>
+              <Multi-Release>true</Multi-Release>
+            </manifestEntries>
+          </archive>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,31 @@
 </dependencyManagement>
 
   <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.3.0</version>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <!--<archive>
+            <manifest>
+              <mainClass>org.acoli.conll.rdf.CoNLLRDFCli</mainClass>
+            </manifest>
+          </archive>-->
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id> <!-- this is used for inheritance merges -->
+            <phase>package</phase> <!-- bind to the packaging phase -->
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
     <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
       <plugins>
         <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->

--- a/run-packaged-jar.sh
+++ b/run-packaged-jar.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Conll-rdf wrapper script using a jar-with-dependencies instead of the default maven-exec.
+# Please read the notice at the start of run.sh if you're not sure what you're seeing here.
+
+# store the path of the conll-rdf/target directory
+conll_dir="$(dirname -- "$(realpath -- "$0")")"
+target_dir="${conll_dir}/target"
+package_jar="${target_dir}/conll-rdf-1.0-SNAPSHOT-jar-with-dependencies.jar"
+
+# if the number of arguments is equal to 0, no class name is provided
+if [ $# -eq 0 ]; then
+	echo "Please give the name of the conll-rdf class you want to run"
+	exit 1
+fi
+
+# Check for presence of packaged jar
+if [ ! -e "${package_jar}" ]; then
+    echo "Please make sure to run package.sh first, and verify the jar-with-dependencies is present in the target folder"
+    exit 1
+fi
+
+class_name=$1
+shift 1
+
+java -cp "${package_jar}" "org.acoli.conll.rdf.${class_name}" "$@"


### PR DESCRIPTION
Needs testing, retesting and rebase.

Missing instructions on versions, maven and $JAVA_HOME, as well as the command to run the jar.
(`java -cp path/to/jar-with-dependencies.jar org.example.exampleClass`, or `java -jar path/to/jar-with-dependencies.jar` if manifest is configured)
Consider changing where the jar is created, also consider whether to add `.` to the classpath for easy log4j.properties stuff